### PR TITLE
Add editor script to stop play mode on Escape

### DIFF
--- a/ITC/Assets/Scripts/EditorPlayModeExitTester.cs
+++ b/ITC/Assets/Scripts/EditorPlayModeExitTester.cs
@@ -1,0 +1,19 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// Utility behaviour for editor-only testing that exits play mode when the Escape key is pressed.
+/// Attach this component to any GameObject in the scene while running in the Unity editor.
+/// </summary>
+public sealed class EditorPlayModeExitTester : MonoBehaviour
+{
+    private void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Escape))
+        {
+            EditorApplication.isPlaying = false;
+        }
+    }
+}
+#endif

--- a/ITC/Assets/Scripts/EditorPlayModeExitTester.cs.meta
+++ b/ITC/Assets/Scripts/EditorPlayModeExitTester.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8d94a4e6603e433d8a3f184842e597af


### PR DESCRIPTION
## Summary
- add an editor-only MonoBehaviour that stops play mode when Escape is pressed

## Testing
- not run (editor utility script)


------
https://chatgpt.com/codex/tasks/task_e_68db499459888329bb6d167ad895e67e