### PR TITLE
Add editor shortcut to log input device status

### DIFF
--- a/ITC/Assets/Editor/InputDeviceStatusReporter.cs
+++ b/ITC/Assets/Editor/InputDeviceStatusReporter.cs
@@ -1,0 +1,80 @@
+#if UNITY_EDITOR
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+[InitializeOnLoad]
+public static class InputDeviceStatusReporter
+{
+    static InputDeviceStatusReporter()
+    {
+        SceneView.duringSceneGui += OnSceneGui;
+    }
+
+    private static void OnSceneGui(SceneView sceneView)
+    {
+        var currentEvent = Event.current;
+        if (currentEvent == null)
+        {
+            return;
+        }
+
+        if (currentEvent.type == EventType.KeyDown && currentEvent.keyCode == KeyCode.M)
+        {
+            LogCurrentDeviceStatus();
+            currentEvent.Use();
+        }
+    }
+
+    private static void LogCurrentDeviceStatus()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("=== Input Device Status ===");
+
+        builder.AppendLine("Connected devices:");
+        if (InputSystem.devices.Count == 0)
+        {
+            builder.AppendLine("  (none)");
+        }
+        else
+        {
+            foreach (var device in InputSystem.devices)
+            {
+                builder.AppendLine($"  - {GetDeviceDisplayName(device)} (layout: {device.layout})");
+            }
+        }
+
+        builder.AppendLine("Disconnected devices:");
+        var disconnectedDevices = InputSystem.disconnectedDevices;
+        if (disconnectedDevices.Count == 0)
+        {
+            builder.AppendLine("  (none)");
+        }
+        else
+        {
+            foreach (var device in disconnectedDevices)
+            {
+                builder.AppendLine($"  - {GetDeviceDisplayName(device)} (layout: {device.layout})");
+            }
+        }
+
+        Debug.Log(builder.ToString());
+    }
+
+    private static string GetDeviceDisplayName(InputDevice device)
+    {
+        if (!string.IsNullOrEmpty(device.displayName))
+        {
+            return device.displayName;
+        }
+
+        if (!string.IsNullOrEmpty(device.name))
+        {
+            return device.name;
+        }
+
+        return device.layout;
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add an editor utility that listens for the M key in Scene view
- log connected and disconnected Input System devices using the new input system API

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db4c9a55fc8329a57ec02651b9331e