### PR TITLE
Improve dialogue input fallback and control scheme sync

### DIFF
--- a/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/UI焦点管理器/DialogueStateManager.cs
+++ b/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/UI焦点管理器/DialogueStateManager.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
 using PixelCrushers.DialogueSystem;
 
@@ -86,24 +87,20 @@ public class DialogueStateManager : MonoBehaviour
 
     public void OnSubmitIntent()
     {
-        // 優先處理對話系統自身的 "Continue" 提示
-        if (DialogueManager.isConversationActive &&
-            DialogueManager.currentConversationState != null &&
-            DialogueManager.currentConversationState.subtitle.sequence == "Continue()")
-        {
-            var currentUI = DialogueManager.Instance.DialogueUI as StandardDialogueUI;
-            if(currentUI != null)
-            {
-                currentUI.OnContinue();
-                return;
-            }
-        }
-
-        // 如果不是Continue狀態，則將提交意圖傳遞給我們的焦點系統
         if (_focusScopeStack.Any())
         {
             _focusScopeStack.Peek()?.HandleSubmission();
+            return;
         }
+
+        if (!DialogueManager.isConversationActive)
+        {
+            return;
+        }
+
+        if (TrySubmitSelectedResponse()) return;
+        if (TrySubmitFirstAvailableResponse()) return;
+        TryContinueConversation();
     }
 
     public void OnCancelIntent()
@@ -173,5 +170,54 @@ public class DialogueStateManager : MonoBehaviour
     public void RunCoroutine(IEnumerator coroutine)
     {
         StartCoroutine(coroutine);
+    }
+
+    private bool TrySubmitSelectedResponse()
+    {
+        var eventSystem = EventSystem.current;
+        if (eventSystem == null) return false;
+
+        var selected = eventSystem.currentSelectedGameObject;
+        if (selected == null) return false;
+
+        var responseButton = selected.GetComponent<StandardUIResponseButton>();
+        if (responseButton == null || !responseButton.isActiveAndEnabled) return false;
+
+        ExecuteEvents.Execute(selected, new BaseEventData(eventSystem), ExecuteEvents.submitHandler);
+        return true;
+    }
+
+    private bool TrySubmitFirstAvailableResponse()
+    {
+        var responses = FindObjectsOfType<StandardUIResponseButton>(true)
+            .Where(r => r.isActiveAndEnabled && r.gameObject.activeInHierarchy)
+            .ToList();
+
+        if (responses.Count == 0) return false;
+
+        var eventSystem = EventSystem.current;
+        if (eventSystem == null) return false;
+
+        var target = responses[0].gameObject;
+        eventSystem.SetSelectedGameObject(target);
+        ExecuteEvents.Execute(target, new BaseEventData(eventSystem), ExecuteEvents.submitHandler);
+        return true;
+    }
+
+    private bool TryContinueConversation()
+    {
+        if (!DialogueManager.isConversationActive) return false;
+
+        var ui = DialogueManager.Instance != null ? DialogueManager.Instance.DialogueUI as StandardDialogueUI : null;
+        if (ui == null)
+        {
+            ui = _dialogueUI != null ? _dialogueUI : FindObjectOfType<StandardDialogueUI>();
+        }
+
+        if (ui == null) return false;
+
+        _dialogueUI = ui;
+        ui.OnContinue();
+        return true;
     }
 }

--- a/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/输入抽象层/DSNewInputBridge.cs
+++ b/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/输入抽象层/DSNewInputBridge.cs
@@ -33,6 +33,18 @@ public class DSNewInputBridge : MonoBehaviour
     public InputActionReference openMenu;
     // ... 可根據你的InputActionAsset添加更多引用
 
+    [Header("PlayerInput Control Scheme Sync (Optional)")]
+    [Tooltip("如需在設備切換時驅動 PlayerInput 的控制方案變更，可在此指定。")]
+    public PlayerInput playerInput;
+    [Tooltip("是否在檢測到設備變化時自動切換 PlayerInput 的控制方案。")]
+    public bool autoSwitchControlScheme = true;
+    [Tooltip("鍵盤輸入時應切換到的控制方案名稱。通常為包含鍵盤+滑鼠的方案。")]
+    public string keyboardControlScheme = "Keyboard&Mouse";
+    [Tooltip("滑鼠輸入時應切換到的控制方案名稱。預設與鍵盤相同，以保證鍵鼠同時可用。")]
+    public string mouseControlScheme = "Keyboard&Mouse";
+    [Tooltip("手柄輸入時應切換到的控制方案名稱。")]
+    public string gamepadControlScheme = "Gamepad";
+
     #region 生命周期与输入订阅
 
     private void OnEnable()
@@ -65,15 +77,71 @@ public class DSNewInputBridge : MonoBehaviour
         actionRef.action.performed += (ctx) =>
         {
             // 在執行原始邏輯之前，先通知 StateManager 設備變更
-            if (DialogueStateManager.Instance != null && ctx.control != null)
+            if (ctx.control != null)
             {
-                DialogueStateManager.Instance.NotifyDeviceUsed(ctx.control.device);
+                NotifyDeviceUsage(ctx.control.device);
             }
             // 然後再執行原始的回調
             handler(ctx);
         };
 
         actionRef.action.Enable();
+    }
+
+    private void NotifyDeviceUsage(InputDevice device)
+    {
+        if (device == null) return;
+
+        if (DialogueStateManager.Instance != null)
+        {
+            DialogueStateManager.Instance.NotifyDeviceUsed(device);
+        }
+
+        if (!autoSwitchControlScheme || playerInput == null) return;
+
+        if (device is Gamepad)
+        {
+            SwitchControlScheme(gamepadControlScheme, new InputDevice[] { device });
+        }
+        else if (device is Keyboard keyboard)
+        {
+            var mouse = Mouse.current;
+            if (mouse != null)
+            {
+                SwitchControlScheme(keyboardControlScheme, new InputDevice[] { keyboard, mouse });
+            }
+            else
+            {
+                SwitchControlScheme(keyboardControlScheme, new InputDevice[] { keyboard });
+            }
+        }
+        else if (device is Mouse mouse)
+        {
+            var keyboard = Keyboard.current;
+            if (keyboard != null)
+            {
+                SwitchControlScheme(mouseControlScheme, new InputDevice[] { keyboard, mouse });
+            }
+            else
+            {
+                SwitchControlScheme(mouseControlScheme, new InputDevice[] { mouse });
+            }
+        }
+    }
+
+    private void SwitchControlScheme(string schemeName, InputDevice[] devices)
+    {
+        if (playerInput == null || string.IsNullOrEmpty(schemeName) || devices == null || devices.Length == 0)
+        {
+            return;
+        }
+
+        if (playerInput.currentControlScheme == schemeName)
+        {
+            return;
+        }
+
+        playerInput.SwitchCurrentControlScheme(schemeName, devices);
     }
 
     private void Unsubscribe(InputActionReference actionRef)


### PR DESCRIPTION
## Summary
- add optional PlayerInput control scheme switching to the new dialogue input bridge so device swaps keep submit bindings active
- expand dialogue submit handling to fall back through response submission and continue events when no focus scope is active

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68dba9cc735883298641cc5b9c326f39