### PR TITLE
Enable pointer delta action subscription for focus indicator

### DIFF
--- a/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/FocusPoint/FocusIndicator.cs
+++ b/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/FocusPoint/FocusIndicator.cs
@@ -43,6 +43,12 @@ public class FocusIndicator : MonoBehaviour
     private void OnEnable()
     {
         SubscribeToEvents();
+
+        if (enableCursorControl && pointerDeltaAction != null && pointerDeltaAction.action != null)
+        {
+            pointerDeltaAction.action.Enable();
+            pointerDeltaAction.action.performed += OnPointerMove;
+        }
     }
 
     private void OnDisable()
@@ -72,6 +78,7 @@ public class FocusIndicator : MonoBehaviour
         if (pointerDeltaAction != null && pointerDeltaAction.action != null)
         {
             pointerDeltaAction.action.performed -= OnPointerMove;
+            pointerDeltaAction.action.Disable();
         }
     }
 


### PR DESCRIPTION
## Summary
- enable the pointer delta input action when the focus indicator is active
- subscribe to pointer movement events to trigger device switching updates
- disable and unsubscribe when the indicator is turned off

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc7b06ac208329a85600f590fd90af