### PR TITLE
Ensure FocusIndicator requires Image component

### DIFF
--- a/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/FocusPoint/FocusIndicator.cs
+++ b/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/FocusPoint/FocusIndicator.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.UI;
 
-[RequireComponent(typeof(RectTransform))]
+[RequireComponent(typeof(RectTransform), typeof(Image))]
 public class FocusIndicator : MonoBehaviour
 {
     [Header("行為設置")]


### PR DESCRIPTION
## Summary
- require an Image component alongside the existing RectTransform on FocusIndicator to prevent null references when toggling visibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc7b198c048329b4780d9baa96bd16