### PR TITLE
Refactor focus management and dock navigation

### DIFF
--- a/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/New/EdgeTransferOnMove.cs
+++ b/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/New/EdgeTransferOnMove.cs
@@ -1,28 +1,50 @@
-using PixelCrushers;
+using ITC.UI.Focus;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
+[AddComponentMenu("Input/Legacy/Edge Transfer On Move")]
 public class EdgeTransferOnMove : MonoBehaviour, IMoveHandler
 {
-    public enum Mode { ToRegisteredKey, ToDock }
+    public enum Mode
+    {
+        UseExplicitDomain,
+        UseMask,
+        FocusDock
+    }
 
-    public Mode mode = Mode.ToRegisteredKey;
-    public FocusKey registeredKey = FocusKey.DialogueMenu;  // 默认交接到“对话菜单”
+    [Tooltip("切换逻辑模式。推荐改用新的 FocusHub 体系，本组件仅作兼容用途。")]
+    public Mode mode = Mode.UseMask;
+
+    [Tooltip("Mode = UseExplicitDomain 时指定目标面板。")]
+    public FocusTag explicitDomain;
+
+    [Tooltip("Mode = UseMask 时使用层级掩码查找目标面板。")]
+    public FocusDomainMask domainMask = new FocusDomainMask(FocusTier.Base, 0);
+
     public MoveDirection triggerDirection = MoveDirection.Right;
 
     public void OnMove(AxisEventData eventData)
     {
         if (eventData.moveDir != triggerDirection) return;
+        if (FocusHub.Instance == null) return;
 
-        if (mode == Mode.ToRegisteredKey)
+        FocusTag target = null;
+        switch (mode)
         {
-            FocusHub.Instance?.Focus(registeredKey);
-        }
-        else // 回 Dock
-        {
-            FocusHub.Instance?.Focus(FocusKey.Dock);
+            case Mode.UseExplicitDomain:
+                target = explicitDomain;
+                break;
+            case Mode.UseMask:
+                target = FocusHub.Instance.Find(domainMask);
+                break;
+            case Mode.FocusDock:
+                target = FocusHub.Instance.Find(new FocusDomainMask(FocusTier.Base, 0));
+                break;
         }
 
-        eventData.Use();
+        if (target != null && FocusHub.Instance.Focus(target))
+        {
+            eventData.Use();
+        }
     }
 }

--- a/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/New/ExternalDockPanel.cs
+++ b/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/New/ExternalDockPanel.cs
@@ -1,16 +1,69 @@
-using System.Collections;
+using System;
 using System.Collections.Generic;
+using ITC.UI.Focus;
 using PixelCrushers;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
-// 如需直接引用标准类，添加命名空间；没有也不报错（可留空）
-// using PixelCrushers.DialogueSystem;
-
 public class ExternalDockPanel : UIPanel
 {
     public enum LayoutMode { Horizontal, Vertical, Grid }
+
+    [Serializable]
+    public class EdgeTransferRule
+    {
+        [Tooltip("Friendly name for the rule (purely descriptive).")]
+        public string name;
+
+        [Tooltip("Index of the button to monitor. -1 代表列表末尾。")]
+        public int itemIndex = 0;
+
+        [Tooltip("When the player moves in this direction from the indexed button, a panel transfer is requested.")]
+        public MoveDirection triggerDirection = MoveDirection.Up;
+
+        [Tooltip("Optional explicit target domain. Overrides mask if assigned.")]
+        public FocusTag explicitDomain;
+
+        [Tooltip("If explicitDomain 未指定，可用层级掩码来寻找面板。")]
+        public FocusDomainMask domainMask = new FocusDomainMask(FocusTier.Base, 0);
+
+        [Tooltip("如果提供，将作为转移后的首选选中对象。")]
+        public Selectable preferredTarget;
+
+        [Tooltip("是否允许在被高层 UI 覆盖时依然强制切换面板。")]
+        public bool forceWhenCovered = false;
+
+        internal int ResolveIndex(int count)
+        {
+            if (count <= 0) return -1;
+            if (itemIndex < 0) return Mathf.Clamp(count + itemIndex, 0, count - 1);
+            return Mathf.Clamp(itemIndex, 0, count - 1);
+        }
+    }
+
+    private class EdgeSentinel : MonoBehaviour, IMoveHandler
+    {
+        private ExternalDockPanel owner;
+        private EdgeTransferRule rule;
+
+        public void Initialize(ExternalDockPanel owner, EdgeTransferRule rule)
+        {
+            this.owner = owner;
+            this.rule = rule;
+        }
+
+        public void OnMove(AxisEventData eventData)
+        {
+            if (owner == null || rule == null) return;
+            if (eventData.moveDir != rule.triggerDirection) return;
+
+            if (owner.TryExecuteEdgeRule(rule))
+            {
+                eventData.Use();
+            }
+        }
+    }
 
     [Header("Dock Items & Layout")]
     public List<Selectable> dockItems = new List<Selectable>();
@@ -18,22 +71,26 @@ public class ExternalDockPanel : UIPanel
     [SerializeField] private int gridColumns = 3;
     [SerializeField] private bool wrap = false;
 
-    [Header("Auto-resolve Dialogue Menu Panel")]
-    [Tooltip("自动查找当前激活的 Dialogue 菜单面板（如 StandardUIMenuPanel）")]
-    [SerializeField] private bool autoResolveDialogueMenuPanel = true;
-
-    [Tooltip("已解析到的对话菜单 UIPanel（运行时自动填充）")]
-    public UIPanel dialogueMenuPanel;
-
-    [Header("Edge → Dialogue 切换方向")]
-    public MoveDirection startEdgeToDialogue = MoveDirection.Left;
-    public MoveDirection endEdgeToDialogue   = MoveDirection.Right;
+    [Header("Edge Transfers")]
+    [SerializeField] private List<EdgeTransferRule> edgeTransferRules = new List<EdgeTransferRule>
+    {
+        new EdgeTransferRule { name = "First → Up", itemIndex = 0, triggerDirection = MoveDirection.Up },
+        new EdgeTransferRule { name = "Last → Down", itemIndex = -1, triggerDirection = MoveDirection.Down }
+    };
 
     [Header("Default Focus")]
     [SerializeField] private Selectable defaultFirstSelected;
 
     [Header("Auto Open On Start")]
     [SerializeField] private bool openOnStart = true;
+
+    private FocusTag focusDomain;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        focusDomain = GetComponent<FocusTag>();
+    }
 
     protected override void OnEnable()
     {
@@ -46,90 +103,29 @@ public class ExternalDockPanel : UIPanel
     {
         base.Start();
 
-        if (openOnStart && !isOpen) Open();
+        if (openOnStart && !isOpen)
+        {
+            Open();
+        }
 
-        // 初次落焦到第 0 项
-        if (dockItems != null && dockItems.Count > 0 && dockItems[0] != null)
-            SetFocus(dockItems[0].gameObject);
-        else if (defaultFirstSelected != null)
-            SetFocus(defaultFirstSelected.gameObject);
+        FocusDefaultOnStart();
+    }
+
+    private void FocusDefaultOnStart()
+    {
+        var target = GetDockItem(0) ?? defaultFirstSelected;
+        if (focusDomain != null)
+        {
+            FocusHub.Instance?.Focus(focusDomain, target);
+        }
+        else if (target != null)
+        {
+            SetFocus(target.gameObject);
+        }
         else
+        {
             CheckFocus();
-
-        if (autoResolveDialogueMenuPanel)
-            StartCoroutine(AutoResolveDialogueMenuPanelRoutine());
-    }
-
-    private IEnumerator AutoResolveDialogueMenuPanelRoutine()
-    {
-        // 刚进场/对话未开始时可能找不到，循环尝试直到找到为止
-        var wait = new WaitForSeconds(0.25f);
-        while (dialogueMenuPanel == null)
-        {
-            TryResolveDialogueMenuPanel();
-            if (dialogueMenuPanel != null) break;
-            yield return wait;
         }
-    }
-
-    private void TryResolveDialogueMenuPanel()
-    {
-        if (dialogueMenuPanel != null) return;
-
-        // 1) 优先：在场景里查找任何激活的 UIPanel，其类型名包含 "MenuPanel"（覆盖官方/自定义）
-#if UNITY_2023_1_OR_NEWER
-        var allPanels = Object.FindObjectsByType<UIPanel>(FindObjectsInactive.Include, FindObjectsSortMode.None);
-#else
-        var allPanels = Resources.FindObjectsOfTypeAll<UIPanel>();
-#endif
-        UIPanel candidate = null;
-        foreach (var p in allPanels)
-        {
-            if (p == null) continue;
-            // 候选条件：名字或类型包含 "MenuPanel"，且在层级中处于激活（activeInHierarchy）
-            var active = p.gameObject.activeInHierarchy;
-            var typeName = p.GetType().Name;
-            if ((typeName.Contains("MenuPanel") || p.name.Contains("MenuPanel")) && active)
-            {
-                candidate = p;
-                break;
-            }
-        }
-
-        // 2) 次优：找不到激活的，就退而求其次——取第一个名字/类型匹配的（即使当前未激活）
-        if (candidate == null)
-        {
-            foreach (var p in allPanels)
-            {
-                if (p == null) continue;
-                var typeName = p.GetType().Name;
-                if (typeName.Contains("MenuPanel") || p.name.Contains("MenuPanel"))
-                {
-                    candidate = p;
-                    break;
-                }
-            }
-        }
-
-        if (candidate != null)
-        {
-            dialogueMenuPanel = candidate;
-            // 可选：如果它当前就是打开状态，顺手校验一下选中对象
-            if (dialogueMenuPanel.isOpen)
-            {
-                var fs = dialogueMenuPanel.firstSelected;
-                if (fs != null) dialogueMenuPanel.SetFocus(fs);
-                else dialogueMenuPanel.CheckFocus();
-            }
-        }
-    }
-
-    private void ApplyFirstSelected()
-    {
-        if (dockItems != null && dockItems.Count > 0 && dockItems[0] != null)
-            firstSelected = dockItems[0].gameObject;
-        else if (defaultFirstSelected != null)
-            firstSelected = defaultFirstSelected.gameObject;
     }
 
     [ContextMenu("Rebuild Navigation")]
@@ -146,73 +142,116 @@ public class ExternalDockPanel : UIPanel
             switch (layout)
             {
                 case LayoutMode.Horizontal:
-                    nav.selectOnLeft  = GetSelectableForIndex(i - 1, i, true);
-                    nav.selectOnRight = GetSelectableForIndex(i + 1, i, false);
+                    nav.selectOnLeft = GetSelectableForIndex(i - 1);
+                    nav.selectOnRight = GetSelectableForIndex(i + 1);
                     break;
                 case LayoutMode.Vertical:
-                    nav.selectOnUp    = GetSelectableForIndex(i - 1, i, true);
-                    nav.selectOnDown  = GetSelectableForIndex(i + 1, i, false);
+                    nav.selectOnUp = GetSelectableForIndex(i - 1);
+                    nav.selectOnDown = GetSelectableForIndex(i + 1);
                     break;
                 case LayoutMode.Grid:
                     int cols = Mathf.Max(1, gridColumns);
-                    nav.selectOnLeft  = GetSelectableForIndex(i - 1,  i, true);
-                    nav.selectOnRight = GetSelectableForIndex(i + 1,  i, false);
-                    nav.selectOnUp    = GetSelectableForIndex(i - cols, i, true);
-                    nav.selectOnDown  = GetSelectableForIndex(i + cols, i, false);
+                    nav.selectOnLeft = GetSelectableForIndex(i - 1);
+                    nav.selectOnRight = GetSelectableForIndex(i + 1);
+                    nav.selectOnUp = GetSelectableForIndex(i - cols);
+                    nav.selectOnDown = GetSelectableForIndex(i + cols);
                     break;
             }
-            sel.navigation = nav;
 
-            AttachEdgeTransfer(i);
+            sel.navigation = nav;
         }
 
+        AttachEdgeSentinels();
         ApplyFirstSelected();
     }
 
-    private Selectable GetSelectableForIndex(int targetIndex, int selfIndex, bool isPrev)
+    private void AttachEdgeSentinels()
     {
-        if (wrap)
+        foreach (var item in dockItems)
         {
-            if (dockItems.Count == 0) return null;
-            targetIndex = (targetIndex % dockItems.Count + dockItems.Count) % dockItems.Count;
-            return dockItems[targetIndex];
+            if (item == null) continue;
+            var sentinels = item.GetComponents<EdgeSentinel>();
+            for (int i = 0; i < sentinels.Length; i++)
+            {
+                if (Application.isPlaying) Destroy(sentinels[i]);
+                else DestroyImmediate(sentinels[i]);
+            }
         }
-        if (targetIndex < 0 || targetIndex >= dockItems.Count) return null;
-        return dockItems[targetIndex];
+
+        if (edgeTransferRules == null) return;
+
+        foreach (var rule in edgeTransferRules)
+        {
+            if (rule == null) continue;
+            int index = rule.ResolveIndex(dockItems.Count);
+            if (index < 0 || index >= dockItems.Count) continue;
+
+            var selectable = dockItems[index];
+            if (selectable == null) continue;
+
+            var sentinel = selectable.gameObject.AddComponent<EdgeSentinel>();
+            sentinel.Initialize(this, rule);
+        }
     }
 
-    private void AttachEdgeTransfer(int i)
+    private Selectable GetSelectableForIndex(int index)
     {
-        var sel = dockItems[i];
-        if (sel == null) return;
-
-        var old = sel.GetComponent<EdgeTransferOnMove>();
-        if (old != null) DestroyImmediate(old);
-
-        if (i == 0)
+        if (dockItems.Count == 0) return null;
+        if (wrap)
         {
-            var t = sel.gameObject.AddComponent<EdgeTransferOnMove>();
-            t.mode = EdgeTransferOnMove.Mode.ToRegisteredKey;
-            t.registeredKey = FocusKey.DialogueMenu;  // 0 号 → 对话菜单
-            t.triggerDirection = startEdgeToDialogue;
+            index = (index % dockItems.Count + dockItems.Count) % dockItems.Count;
+            return dockItems[index];
         }
 
-        if (i == dockItems.Count - 1)
+        if (index < 0 || index >= dockItems.Count) return null;
+        return dockItems[index];
+    }
+
+    private Selectable GetDockItem(int index)
+    {
+        if (dockItems == null || dockItems.Count == 0) return null;
+        index = Mathf.Clamp(index, 0, dockItems.Count - 1);
+        return dockItems[index];
+    }
+
+    private void ApplyFirstSelected()
+    {
+        var first = GetDockItem(0) ?? defaultFirstSelected;
+        if (first != null)
         {
-            var t = sel.gameObject.AddComponent<EdgeTransferOnMove>();
-            t.mode = EdgeTransferOnMove.Mode.ToRegisteredKey;
-            t.registeredKey = FocusKey.DialogueMenu;  // 末位 → 对话菜单
-            t.triggerDirection = endEdgeToDialogue;
+            firstSelected = first.gameObject;
         }
+    }
+
+    private bool TryExecuteEdgeRule(EdgeTransferRule rule)
+    {
+        if (FocusHub.Instance == null) return false;
+
+        var domain = rule.explicitDomain != null ? rule.explicitDomain : FocusHub.Instance.Find(rule.domainMask);
+        if (domain == null) return false;
+
+        var preferred = rule.preferredTarget != null ? rule.preferredTarget.gameObject : null;
+        var flags = rule.forceWhenCovered ? FocusHub.FocusRequestFlags.Force : FocusHub.FocusRequestFlags.None;
+        return FocusHub.Instance.Focus(domain, preferred, flags);
     }
 
     // 供别处调用：把 Dock 拉到栈顶并定位到某项
     public void FocusDock(int index = 0)
     {
-        TakeFocus();
-        var target = (dockItems != null && dockItems.Count > 0) ? dockItems[Mathf.Clamp(index, 0, dockItems.Count - 1)] : null;
-        if (target != null) SetFocus(target.gameObject);
-        else if (firstSelected != null) SetFocus(firstSelected);
-        else CheckFocus();
+        var target = GetDockItem(index) ?? defaultFirstSelected;
+        if (focusDomain != null)
+        {
+            FocusHub.Instance?.Focus(focusDomain, target);
+        }
+        else if (target != null)
+        {
+            TakeFocus();
+            SetFocus(target.gameObject);
+        }
+        else
+        {
+            TakeFocus();
+            CheckFocus();
+        }
     }
 }

--- a/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/New/FocusHub.cs
+++ b/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/New/FocusHub.cs
@@ -1,37 +1,417 @@
+using System;
 using System.Collections.Generic;
-using PixelCrushers;
 using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
 
-public enum FocusKey { Dock, DialogueMenu, Settings, Inventory, Custom1, Custom2 }
-
-public class FocusHub : MonoBehaviour
+namespace ITC.UI.Focus
 {
-    public static FocusHub Instance { get; private set; }
-
-    private readonly Dictionary<FocusKey, UIPanel> map = new Dictionary<FocusKey, UIPanel>();
-
-    private void Awake()
+    public class FocusHub : MonoBehaviour
     {
-        if (Instance != null && Instance != this) { Destroy(gameObject); return; }
-        Instance = this;
-        DontDestroyOnLoad(gameObject);
-    }
+        [Flags]
+        public enum FocusRequestFlags
+        {
+            None = 0,
+            Force = 1 << 0,
+            FromSelection = 1 << 1
+        }
 
-    public void Register(FocusKey key, UIPanel panel) => map[key] = panel;
+        private struct DomainState
+        {
+            public FocusTag domain;
+            public GameObject lastSelected;
+        }
 
-    public void Unregister(UIPanel panel)
-    {
-        foreach (var kv in new List<KeyValuePair<FocusKey, UIPanel>>(map))
-            if (kv.Value == panel) map.Remove(kv.Key);
-    }
+        public static FocusHub Instance { get; private set; }
 
-    public void Focus(FocusKey key, GameObject preferred = null)
-    {
-        if (!map.TryGetValue(key, out var panel) || panel == null) return;
-        panel.TakeFocus();
-        if (preferred != null) panel.SetFocus(preferred);
-        else if (panel.firstSelected != null) panel.SetFocus(panel.firstSelected);
-        else panel.CheckFocus();
+        private static readonly List<FocusTag> PendingRegistrations = new List<FocusTag>();
+
+        private readonly Dictionary<FocusTag, DomainState> registry = new Dictionary<FocusTag, DomainState>();
+        private readonly List<FocusTag> focusStack = new List<FocusTag>();
+        private readonly Dictionary<FocusTier, FocusTag> activeByTier = new Dictionary<FocusTier, FocusTag>();
+
+        private GameObject lastObservedSelection;
+        private bool suppressSelectionTracking;
+
+        public event Action<FocusTag> FocusChanged;
+
+        public FocusTag Current => focusStack.Count > 0 ? focusStack[focusStack.Count - 1] : null;
+        public IReadOnlyList<FocusTag> Stack => focusStack;
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            if (PendingRegistrations.Count > 0)
+            {
+                for (int i = 0; i < PendingRegistrations.Count; i++)
+                {
+                    var domain = PendingRegistrations[i];
+                    if (domain == null) continue;
+                    Register(domain, domain.AutoFocusOnEnable);
+                }
+
+                PendingRegistrations.Clear();
+            }
+        }
+
+        private void Update()
+        {
+            if (suppressSelectionTracking) return;
+
+            var eventSystem = EventSystem.current;
+            if (eventSystem == null) return;
+
+            var selected = eventSystem.currentSelectedGameObject;
+            if (selected == lastObservedSelection) return;
+
+            lastObservedSelection = selected;
+            if (selected == null) return;
+
+            var domain = ResolveDomain(selected);
+            if (domain == null) return;
+            if (!registry.ContainsKey(domain)) return;
+
+            RememberSelection(domain, selected);
+
+            if (Current == domain) return;
+            if (!CanReach(domain, FocusRequestFlags.None)) return;
+
+            Focus(domain, selected, FocusRequestFlags.FromSelection);
+        }
+
+        public static void EnqueueRegistration(FocusTag domain)
+        {
+            if (domain == null) return;
+            if (PendingRegistrations.Contains(domain)) return;
+            PendingRegistrations.Add(domain);
+        }
+
+        public static void RemovePendingRegistration(FocusTag domain)
+        {
+            if (domain == null) return;
+            PendingRegistrations.Remove(domain);
+        }
+
+        public void Register(FocusTag domain, bool autoFocus)
+        {
+            if (domain == null || domain.Panel == null) return;
+
+            registry[domain] = new DomainState { domain = domain, lastSelected = domain.GetLastSelected() };
+            domain.SetInteractionEnabled(false);
+
+            if (autoFocus)
+            {
+                Focus(domain, domain.GetLastSelected() ?? domain.GetDefaultFocus(), FocusRequestFlags.Force);
+            }
+            else if (focusStack.Count == 0)
+            {
+                RefocusCurrentTop();
+            }
+            else
+            {
+                UpdateRaycastState();
+            }
+        }
+
+        public void Unregister(FocusTag domain)
+        {
+            if (domain == null) return;
+
+            registry.Remove(domain);
+
+            for (int i = focusStack.Count - 1; i >= 0; i--)
+            {
+                if (focusStack[i] == domain)
+                {
+                    focusStack.RemoveAt(i);
+                }
+            }
+
+            UpdateRaycastState();
+            RefocusCurrentTop();
+        }
+
+        public bool Focus(FocusTag domain, GameObject preferred = null)
+        {
+            return Focus(domain, preferred, FocusRequestFlags.None);
+        }
+
+        public bool Focus(FocusTag domain, Selectable preferred)
+        {
+            return Focus(domain, preferred ? preferred.gameObject : null, FocusRequestFlags.None);
+        }
+
+        public bool Focus(FocusDomainMask mask, GameObject preferred = null)
+        {
+            var domain = Find(mask);
+            if (domain == null) return false;
+            return Focus(domain, preferred);
+        }
+
+        public bool Focus(FocusDomainMask mask, GameObject preferred, FocusRequestFlags flags)
+        {
+            var domain = Find(mask);
+            if (domain == null) return false;
+            return Focus(domain, preferred, flags);
+        }
+
+        public bool Focus(FocusTag domain, GameObject preferred, FocusRequestFlags flags)
+        {
+            if (domain == null || !domain.isActiveAndEnabled) return false;
+            if (!registry.ContainsKey(domain)) return false;
+            if (!CanReach(domain, flags)) return false;
+
+            RemoveFromStack(domain);
+            RemoveSameTier(domain.Tier);
+
+            focusStack.Add(domain);
+            ApplyFocus(domain, preferred, flags);
+            return true;
+        }
+
+        public bool PopCurrent()
+        {
+            if (focusStack.Count == 0) return false;
+            focusStack.RemoveAt(focusStack.Count - 1);
+            RefocusCurrentTop();
+            return true;
+        }
+
+        public bool PopToTier(FocusTier tier)
+        {
+            bool removed = false;
+            for (int i = focusStack.Count - 1; i >= 0; i--)
+            {
+                if (focusStack[i].Tier >= tier)
+                {
+                    focusStack.RemoveAt(i);
+                    removed = true;
+                }
+            }
+
+            if (!removed) return false;
+            RefocusCurrentTop();
+            return true;
+        }
+
+        public FocusTag Find(FocusDomainMask mask)
+        {
+            foreach (var kv in registry)
+            {
+                if (kv.Key != null && kv.Key.Mask == mask)
+                {
+                    return kv.Key;
+                }
+            }
+
+            return null;
+        }
+
+        public FocusTag GetActiveDomain(FocusTier tier)
+        {
+            if (activeByTier.TryGetValue(tier, out var domain)) return domain;
+            return null;
+        }
+
+        public bool HasBlockingTier => focusStack.Count > 0 && focusStack[focusStack.Count - 1].Tier > FocusTier.Base;
+
+        private bool CanReach(FocusTag domain, FocusRequestFlags flags)
+        {
+            if ((flags & FocusRequestFlags.Force) != 0) return true;
+            if (focusStack.Count == 0) return true;
+
+            var top = focusStack[focusStack.Count - 1];
+            if (top == domain) return true;
+            if (domain.Tier < top.Tier) return false;
+            return true;
+        }
+
+        private void RemoveFromStack(FocusTag domain)
+        {
+            for (int i = focusStack.Count - 1; i >= 0; i--)
+            {
+                if (focusStack[i] == domain)
+                {
+                    focusStack.RemoveAt(i);
+                }
+            }
+        }
+
+        private void RemoveSameTier(FocusTier tier)
+        {
+            for (int i = focusStack.Count - 1; i >= 0; i--)
+            {
+                if (focusStack[i].Tier == tier)
+                {
+                    focusStack.RemoveAt(i);
+                    break;
+                }
+            }
+        }
+
+        private void ApplyFocus(FocusTag domain, GameObject preferred, FocusRequestFlags flags)
+        {
+            UpdateRaycastState();
+
+            GameObject target = preferred;
+            if (target != null && !domain.Contains(target))
+            {
+                target = null;
+            }
+
+            if (target == null && registry.TryGetValue(domain, out var state))
+            {
+                if (state.lastSelected != null && domain.Contains(state.lastSelected))
+                {
+                    target = state.lastSelected;
+                }
+            }
+
+            if (target == null)
+            {
+                target = domain.GetDefaultFocus();
+            }
+
+            suppressSelectionTracking = true;
+            domain.EnsureOpen();
+            domain.ApplyFocus(target);
+            suppressSelectionTracking = false;
+
+            var current = EventSystem.current ? EventSystem.current.currentSelectedGameObject : null;
+            if (current == null) current = target;
+            RememberSelection(domain, current);
+            lastObservedSelection = current;
+
+            FocusChanged?.Invoke(domain);
+        }
+
+        private void RememberSelection(FocusTag domain, GameObject selected)
+        {
+            if (domain == null) return;
+            if (selected == null) return;
+
+            domain.RememberSelection(selected);
+            if (!registry.ContainsKey(domain)) return;
+
+            var state = registry[domain];
+            state.lastSelected = domain.Contains(selected) ? selected : state.lastSelected;
+            registry[domain] = state;
+        }
+
+        private void UpdateRaycastState()
+        {
+            activeByTier.Clear();
+            for (int i = focusStack.Count - 1; i >= 0; i--)
+            {
+                var domain = focusStack[i];
+                if (domain == null) continue;
+                if (!activeByTier.ContainsKey(domain.Tier))
+                {
+                    activeByTier[domain.Tier] = domain;
+                }
+            }
+
+            FocusTier highestTier = FocusTier.Base;
+            if (focusStack.Count > 0)
+            {
+                highestTier = focusStack[focusStack.Count - 1].Tier;
+            }
+
+            foreach (var kv in registry)
+            {
+                var domain = kv.Key;
+                if (domain == null) continue;
+
+                bool enable = false;
+                if (activeByTier.TryGetValue(domain.Tier, out var active) && active == domain)
+                {
+                    enable = domain.Tier == highestTier;
+                }
+
+                domain.SetInteractionEnabled(enable);
+            }
+        }
+
+        private void RefocusCurrentTop()
+        {
+            if (focusStack.Count == 0)
+            {
+                var fallback = GetFallbackForTier(FocusTier.Base);
+                if (fallback != null)
+                {
+                    if (!Focus(fallback, fallback.GetLastSelected() ?? fallback.GetDefaultFocus(), FocusRequestFlags.Force))
+                    {
+                        UpdateRaycastState();
+                        FocusChanged?.Invoke(null);
+                    }
+                }
+                else
+                {
+                    UpdateRaycastState();
+                    FocusChanged?.Invoke(null);
+                }
+
+                return;
+            }
+
+            var top = focusStack[focusStack.Count - 1];
+            if (top == null || !top.isActiveAndEnabled)
+            {
+                focusStack.RemoveAt(focusStack.Count - 1);
+                RefocusCurrentTop();
+                return;
+            }
+
+            ApplyFocus(top, top.GetLastSelected(), FocusRequestFlags.Force);
+        }
+
+        private FocusTag GetFallbackForTier(FocusTier tier)
+        {
+            FocusTag best = null;
+            int bestOrder = int.MaxValue;
+
+            foreach (var kv in registry)
+            {
+                var domain = kv.Key;
+                if (domain == null) continue;
+                if (domain.Tier != tier) continue;
+                if (!domain.AllowFallback) continue;
+
+                if (domain.OrderInTier < bestOrder)
+                {
+                    bestOrder = domain.OrderInTier;
+                    best = domain;
+                }
+            }
+
+            return best;
+        }
+
+        private FocusTag ResolveDomain(GameObject go)
+        {
+            if (go == null) return null;
+
+            for (int i = focusStack.Count - 1; i >= 0; i--)
+            {
+                var candidate = focusStack[i];
+                if (candidate != null && candidate.Contains(go)) return candidate;
+            }
+
+            foreach (var kv in registry)
+            {
+                var candidate = kv.Key;
+                if (candidate != null && candidate.Contains(go)) return candidate;
+            }
+
+            return null;
+        }
     }
 }
-

--- a/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/New/FocusTag.cs
+++ b/ITC/Assets/Scripts/唐今脚本/Core（入口、GameState、ServiceLocatorDI、EventBus）/Input/New/FocusTag.cs
@@ -1,15 +1,191 @@
-using System.Collections.Generic;
+using System;
 using PixelCrushers;
 using UnityEngine;
+using UnityEngine.UI;
 
-// 挂在任何 UIPanel 上即可把它注册为某个 Key（动态实例的面板也适用）
-[RequireComponent(typeof(UIPanel))]
-public class FocusTag : MonoBehaviour
+namespace ITC.UI.Focus
 {
-    public FocusKey key = FocusKey.Custom1;
+    [Serializable]
+    public struct FocusDomainMask : IEquatable<FocusDomainMask>
+    {
+        public FocusTier tier;
+        public int orderInTier;
 
-    private UIPanel panel;
-    private void Awake() => panel = GetComponent<UIPanel>();
-    private void OnEnable() { if (panel != null) FocusHub.Instance?.Register(key, panel); }
-    private void OnDisable(){ if (panel != null) FocusHub.Instance?.Unregister(panel); }
+        public FocusDomainMask(FocusTier tier, int order)
+        {
+            this.tier = tier;
+            orderInTier = order;
+        }
+
+        public bool Equals(FocusDomainMask other) => tier == other.tier && orderInTier == other.orderInTier;
+        public override bool Equals(object obj) => obj is FocusDomainMask other && Equals(other);
+        public override int GetHashCode() => ((int)tier * 397) ^ orderInTier;
+        public static bool operator ==(FocusDomainMask left, FocusDomainMask right) => left.Equals(right);
+        public static bool operator !=(FocusDomainMask left, FocusDomainMask right) => !left.Equals(right);
+        public override string ToString() => $"{tier}-{orderInTier}";
+    }
+
+    public enum FocusTier
+    {
+        Base = 0,
+        Modal = 1,
+        Top = 2
+    }
+
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(UIPanel))]
+    public class FocusTag : MonoBehaviour
+    {
+        [Header("Domain Identity")]
+        [SerializeField] private FocusTier tier = FocusTier.Base;
+        [SerializeField] private int orderInTier = 0;
+        [SerializeField] private bool allowFallback = true;
+
+        [Header("Behaviour")]
+        [SerializeField] private bool autoFocusOnEnable = false;
+        [SerializeField] private bool autoOpenOnFocus = true;
+        [SerializeField] private bool autoCloseOnDisable = false;
+
+        [Header("Default Focus")]
+        [SerializeField] private Selectable defaultSelectable;
+
+        [Header("Canvas Groups (optional)")]
+        [SerializeField] private CanvasGroup[] managedCanvasGroups;
+
+        private UIPanel panel;
+        private GameObject lastSelected;
+        private bool canvasGroupsResolved;
+
+        public FocusTier Tier => tier;
+        public int OrderInTier => orderInTier;
+        public bool AllowFallback => allowFallback;
+        public FocusDomainMask Mask => new FocusDomainMask(tier, orderInTier);
+        internal bool AutoFocusOnEnable => autoFocusOnEnable;
+
+        public UIPanel Panel => panel;
+
+        private void Awake()
+        {
+            panel = GetComponent<UIPanel>();
+        }
+
+        private void OnEnable()
+        {
+            if (FocusHub.Instance != null)
+            {
+                FocusHub.Instance.Register(this, autoFocusOnEnable);
+            }
+            else
+            {
+                FocusHub.EnqueueRegistration(this);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (autoCloseOnDisable && panel != null && panel.isOpen)
+            {
+                panel.Close();
+            }
+
+            FocusHub.RemovePendingRegistration(this);
+            FocusHub.Instance?.Unregister(this);
+        }
+
+        internal GameObject GetDefaultFocus()
+        {
+            if (defaultSelectable != null) return defaultSelectable.gameObject;
+            if (panel != null)
+            {
+                if (panel.firstSelected != null) return panel.firstSelected;
+                if (panel.defaultControl != null) return panel.defaultControl;
+            }
+
+            return null;
+        }
+
+        internal void EnsureOpen()
+        {
+            if (panel != null && autoOpenOnFocus && !panel.isOpen)
+            {
+                panel.Open();
+            }
+        }
+
+        internal void ApplyFocus(GameObject target)
+        {
+            if (panel == null) return;
+
+            EnsureOpen();
+            panel.TakeFocus();
+
+            if (target != null)
+            {
+                panel.SetFocus(target);
+            }
+            else if (panel.firstSelected != null)
+            {
+                panel.SetFocus(panel.firstSelected);
+            }
+            else
+            {
+                panel.CheckFocus();
+            }
+        }
+
+        internal void RememberSelection(GameObject go)
+        {
+            if (go != null && Contains(go))
+            {
+                lastSelected = go;
+            }
+        }
+
+        internal GameObject GetLastSelected()
+        {
+            if (lastSelected != null && Contains(lastSelected)) return lastSelected;
+            return null;
+        }
+
+        internal bool Contains(GameObject go)
+        {
+            if (go == null || panel == null) return false;
+            return go.transform.IsChildOf(panel.transform);
+        }
+
+        internal void SetInteractionEnabled(bool enable)
+        {
+            EnsureCanvasGroups();
+
+            if (managedCanvasGroups == null) return;
+            for (int i = 0; i < managedCanvasGroups.Length; i++)
+            {
+                var group = managedCanvasGroups[i];
+                if (group == null) continue;
+                group.interactable = enable;
+                group.blocksRaycasts = enable;
+            }
+        }
+
+        private void EnsureCanvasGroups()
+        {
+            if (canvasGroupsResolved) return;
+
+            if (managedCanvasGroups == null || managedCanvasGroups.Length == 0)
+            {
+                var group = GetComponentInChildren<CanvasGroup>(true);
+                if (group != null)
+                {
+                    managedCanvasGroups = new[] { group };
+                }
+            }
+
+            canvasGroupsResolved = true;
+        }
+
+        public void RequestFocus(GameObject preferred = null)
+        {
+            FocusHub.Instance?.Focus(this, preferred);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- replace the FocusHub/FocusTag pair with a tiered focus-domain stack that tracks selection anchors and fallback order
- fold edge-transfer rules into ExternalDockPanel so boundary navigation triggers domain switches via the new FocusHub APIs
- refresh the legacy EdgeTransferOnMove shim to work with the refactored focus system and mask-based lookups

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68df8c62c4048329a2cb2133f9bae6f8