### PR TITLE
Add Audio Manager Pro clip test script

### DIFF
--- a/ITC/Assets/Scripts/TestScripts.meta
+++ b/ITC/Assets/Scripts/TestScripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 74e3b422a8c84a95a7b6b9b0b74c585a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/TestScripts/AudioManagerProClipTester.cs
+++ b/ITC/Assets/Scripts/TestScripts/AudioManagerProClipTester.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple runtime utility that plays a random clip from a manually assigned Audio Manager Pro SFXGroup
+/// whenever the user presses the P key.
+/// </summary>
+public class AudioManagerProClipTester : MonoBehaviour
+{
+    [Header("Audio Manager Pro")]
+    [Tooltip("Clip group created by Audio Manager Pro. A random clip will be played from this group when P is pressed.")]
+    [SerializeField] private SFXGroup clipGroup;
+
+    [Tooltip("Keyboard key used to trigger playback. Defaults to 'P'.")]
+    [SerializeField] private KeyCode triggerKey = KeyCode.P;
+
+    private void Awake()
+    {
+        if (clipGroup == null)
+        {
+            Debug.LogWarning($"{nameof(AudioManagerProClipTester)} on '{name}' is missing a clip group reference.");
+        }
+    }
+
+    private void Update()
+    {
+        if (Input.GetKeyDown(triggerKey))
+        {
+            if (clipGroup == null)
+            {
+                Debug.LogWarning($"Cannot play clip group because none is assigned on {nameof(AudioManagerProClipTester)} attached to '{name}'.");
+                return;
+            }
+
+            if (SFXManager.Main == null)
+            {
+                Debug.LogWarning("No active Audio Manager Pro SFXManager was found in the scene.");
+                return;
+            }
+
+            SFXManager.Main.Play(clipGroup);
+        }
+    }
+}

--- a/ITC/Assets/Scripts/TestScripts/AudioManagerProClipTester.cs.meta
+++ b/ITC/Assets/Scripts/TestScripts/AudioManagerProClipTester.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c19f39663a545c096310c0688c16fd0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add a TestScripts folder for experimental audio behaviours
- implement an Audio Manager Pro clip tester MonoBehaviour that plays a random clip from an assigned SFXGroup when P is pressed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e9057146cc8329956c47f1026452d4