### PR TITLE
Add lightweight UITween track player

### DIFF
--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b64ed8e5414148508136207b5513900b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenTrackEditor.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenTrackEditor.cs
@@ -1,0 +1,84 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+
+[CustomEditor(typeof(UITweenTrack))]
+public class UITweenTrackEditor : Editor
+{
+    SerializedProperty _tracksProp;
+    SerializedProperty _useUnscaledProp;
+
+    void OnEnable()
+    {
+        _tracksProp = serializedObject.FindProperty("tracks");
+        _useUnscaledProp = serializedObject.FindProperty("useUnscaledIntervals");
+    }
+
+    public override void OnInspectorGUI()
+    {
+        if (serializedObject.isEditingMultipleObjects)
+        {
+            EditorGUILayout.HelpBox("暂不支持多对象同时编辑 UITweenTrack。", MessageType.Info);
+            return;
+        }
+
+        serializedObject.Update();
+
+        EditorGUILayout.PropertyField(_useUnscaledProp);
+        EditorGUILayout.Space();
+
+        DrawTracks();
+
+        serializedObject.ApplyModifiedProperties();
+    }
+
+    void DrawTracks()
+    {
+        EditorGUILayout.LabelField("轨道设置", EditorStyles.boldLabel);
+        if (_tracksProp == null)
+        {
+            EditorGUILayout.HelpBox("未找到轨道数据。", MessageType.Warning);
+            return;
+        }
+
+        for (int i = 0; i < _tracksProp.arraySize; i++)
+        {
+            var trackProp = _tracksProp.GetArrayElementAtIndex(i);
+            using (new EditorGUILayout.VerticalScope("box"))
+            {
+                EditorGUILayout.PropertyField(trackProp.FindPropertyRelative("trackName"), new GUIContent("轨道名称"));
+
+                var intervalProp = trackProp.FindPropertyRelative("uniformInterval");
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    EditorGUILayout.PropertyField(intervalProp, new GUIContent("统一间隔"));
+                    if (GUILayout.Button("应用到轨道", GUILayout.Width(100f)))
+                    {
+                        ApplyUniformInterval(i, intervalProp.floatValue);
+                    }
+                }
+
+                EditorGUILayout.PropertyField(trackProp.FindPropertyRelative("items"), new GUIContent("轨道元素"), true);
+            }
+        }
+
+        if (GUILayout.Button("添加新轨道"))
+        {
+            _tracksProp.arraySize++;
+        }
+    }
+
+    void ApplyUniformInterval(int trackIndex, float interval)
+    {
+        foreach (var obj in targets)
+        {
+            if (obj is UITweenTrack track)
+            {
+                Undo.RecordObject(track, "Apply Uniform Interval");
+                track.ApplyUniformInterval(trackIndex, interval);
+                EditorUtility.SetDirty(track);
+            }
+        }
+    }
+}
+#endif

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenTrackEditor.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenTrackEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bafb9910322842b491ee9da3d90b9bf7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenTrack.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenTrack.cs
@@ -1,0 +1,144 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 轻量化的轨道播放器，用于顺序触发多个 <see cref="UITweenPlayer"/>。
+/// </summary>
+[DisallowMultipleComponent]
+public class UITweenTrack : MonoBehaviour
+{
+    [System.Serializable]
+    public class TrackItem
+    {
+        [Tooltip("需要播放动画的 UI 对象，必须带有 UITweenPlayer 组件。")]
+        public UITweenPlayer player;
+
+        [Tooltip("在 Library 中的动画名称，仅支持按名称播放。")]
+        public string presetName;
+
+        [Tooltip("该动画播放完毕后的间隔，单位：秒。")]
+        public float delayAfterPlay = 0.1f;
+    }
+
+    [System.Serializable]
+    public class Track
+    {
+        [Tooltip("轨道名称，仅用于标识。")]
+        public string trackName;
+
+        [Tooltip("为该轨道全部元素统一设置的播放间隔。点击“应用到轨道”按钮后生效。")]
+        public float uniformInterval = 0.1f;
+
+        [Tooltip("轨道包含的元素，添加顺序即播放顺序。")]
+        public List<TrackItem> items = new List<TrackItem>();
+
+        public void ApplyUniformInterval(float interval)
+        {
+            uniformInterval = Mathf.Max(0f, interval);
+            foreach (var item in items)
+            {
+                if (item == null) continue;
+                item.delayAfterPlay = uniformInterval;
+            }
+        }
+    }
+
+    [Tooltip("轨道集合，可自由增删。")]
+    public List<Track> tracks = new List<Track>();
+
+    [Tooltip("播放间隔是否使用真实时间（忽略 TimeScale）。")]
+    public bool useUnscaledIntervals = true;
+
+    readonly Dictionary<int, Coroutine> _runningTracks = new();
+
+    public void PlayTrackByIndex_Event(int trackIndex)
+    {
+        PlayTrack(trackIndex);
+    }
+
+    public void PlayTrackByName(string trackName)
+    {
+        if (string.IsNullOrEmpty(trackName)) return;
+
+        for (int i = 0; i < tracks.Count; i++)
+        {
+            if (tracks[i] != null && tracks[i].trackName == trackName)
+            {
+                PlayTrack(i);
+                return;
+            }
+        }
+    }
+
+    public void PlayTrack(int trackIndex)
+    {
+        if (!isActiveAndEnabled) return;
+        if (trackIndex < 0 || trackIndex >= tracks.Count) return;
+
+        StopTrack(trackIndex);
+        var track = tracks[trackIndex];
+        if (track == null) return;
+
+        var routine = StartCoroutine(RunTrack(trackIndex, track));
+        _runningTracks[trackIndex] = routine;
+    }
+
+    public void StopTrack(int trackIndex)
+    {
+        if (_runningTracks.TryGetValue(trackIndex, out var routine) && routine != null)
+        {
+            StopCoroutine(routine);
+        }
+        _runningTracks.Remove(trackIndex);
+    }
+
+    public void StopAllTracks()
+    {
+        foreach (var routine in _runningTracks.Values)
+        {
+            if (routine != null)
+            {
+                StopCoroutine(routine);
+            }
+        }
+        _runningTracks.Clear();
+    }
+
+    public void ApplyUniformInterval(int trackIndex, float interval)
+    {
+        if (trackIndex < 0 || trackIndex >= tracks.Count) return;
+        var track = tracks[trackIndex];
+        track?.ApplyUniformInterval(interval);
+    }
+
+    IEnumerator RunTrack(int trackIndex, Track track)
+    {
+        foreach (var item in track.items)
+        {
+            if (item == null || item.player == null) continue;
+
+            item.player.PlayMasterByName(item.presetName);
+
+            float waitDuration = Mathf.Max(0f, item.delayAfterPlay);
+            if (waitDuration > 0f)
+            {
+                if (useUnscaledIntervals)
+                {
+                    yield return new WaitForSecondsRealtime(waitDuration);
+                }
+                else
+                {
+                    yield return new WaitForSeconds(waitDuration);
+                }
+            }
+        }
+
+        _runningTracks.Remove(trackIndex);
+    }
+
+    void OnDisable()
+    {
+        StopAllTracks();
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenTrack.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenTrack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: abef3c196b634641a240cb1806424b65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add a UITweenTrack component that sequences UITweenPlayer entries on named tracks with master playback and configurable delays
- add a custom inspector to streamline editing tracks and applying uniform play intervals

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68eb06ff32e48329bd64e623671fb319