### PR TITLE
Enhance tween editors with preset pickers

### DIFF
--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/Editor.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 501106636bf04b0eb1cfdb03fe350639
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/Editor/UIStateMachineEditor.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/Editor/UIStateMachineEditor.cs
@@ -1,0 +1,150 @@
+#if UNITY_EDITOR
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+[CustomEditor(typeof(UIStateMachine))]
+public class UIStateMachineEditor : Editor
+{
+    SerializedProperty _stateAnimationsProp;
+    SerializedProperty _startingStateProp;
+
+    void OnEnable()
+    {
+        _stateAnimationsProp = serializedObject.FindProperty("stateAnimations");
+        _startingStateProp = serializedObject.FindProperty("startingState");
+    }
+
+    public override void OnInspectorGUI()
+    {
+        if (serializedObject.isEditingMultipleObjects)
+        {
+            EditorGUILayout.HelpBox("暂不支持多对象同时编辑 UIStateMachine。", MessageType.Info);
+            return;
+        }
+
+        serializedObject.Update();
+
+        EditorGUILayout.PropertyField(_startingStateProp, new GUIContent("初始状态"));
+        EditorGUILayout.Space();
+
+        DrawStateBindings();
+
+        serializedObject.ApplyModifiedProperties();
+    }
+
+    void DrawStateBindings()
+    {
+        var machine = (UIStateMachine)target;
+        var player = machine != null ? machine.GetComponent<UITweenPlayer>() : null;
+
+        IReadOnlyList<UITweenPresetOption> options = UITweenEditorUtility.GetPresetOptions(player);
+        if (player == null)
+        {
+            EditorGUILayout.HelpBox("未找到同物体上的 UITweenPlayer，库中预设下拉功能将不可用。", MessageType.Info);
+        }
+        else if (options.Count == 0)
+        {
+            EditorGUILayout.HelpBox("当前 UITweenPlayer 未关联任何预设或库，暂无可选项。", MessageType.Info);
+        }
+
+        EditorGUILayout.LabelField("状态动画绑定", EditorStyles.boldLabel);
+
+        if (_stateAnimationsProp == null)
+        {
+            EditorGUILayout.HelpBox("未找到状态动画数据。", MessageType.Warning);
+            return;
+        }
+
+        for (int i = 0; i < _stateAnimationsProp.arraySize; i++)
+        {
+            var bindingProp = _stateAnimationsProp.GetArrayElementAtIndex(i);
+            using (new EditorGUILayout.VerticalScope("box"))
+            {
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    EditorGUILayout.PropertyField(bindingProp.FindPropertyRelative("state"), new GUIContent("状态"));
+                    if (GUILayout.Button("删除", GUILayout.Width(50f)))
+                    {
+                        _stateAnimationsProp.DeleteArrayElementAtIndex(i);
+                        break;
+                    }
+                }
+
+                DrawPresetReferenceField(bindingProp.FindPropertyRelative("onEnterPreset"), new GUIContent("进入动画"), options);
+                DrawPresetReferenceField(bindingProp.FindPropertyRelative("onExitPreset"), new GUIContent("退出动画"), options);
+                EditorGUILayout.PropertyField(bindingProp.FindPropertyRelative("reverseOnExit"), new GUIContent("退出时反播"));
+            }
+        }
+
+        if (GUILayout.Button("添加状态绑定"))
+        {
+            _stateAnimationsProp.arraySize++;
+        }
+    }
+
+    void DrawPresetReferenceField(SerializedProperty presetProp, GUIContent label, IReadOnlyList<UITweenPresetOption> options)
+    {
+        using (new EditorGUILayout.HorizontalScope())
+        {
+            EditorGUILayout.PropertyField(presetProp, label);
+            using (new EditorGUI.DisabledScope(options == null || options.Count == 0))
+            {
+                if (GUILayout.Button("库中选择", GUILayout.Width(80f)))
+                {
+                    ShowPresetReferenceMenu(presetProp, options);
+                }
+            }
+        }
+
+        if (presetProp.objectReferenceValue is UITweenPreset preset)
+        {
+            string presetName = string.IsNullOrEmpty(preset.presetName) ? "<未命名>" : preset.presetName;
+            EditorGUILayout.LabelField("Preset 名称", presetName);
+        }
+    }
+
+    void ShowPresetReferenceMenu(SerializedProperty presetProp, IReadOnlyList<UITweenPresetOption> options)
+    {
+        var menu = new GenericMenu();
+        if (options == null || options.Count == 0)
+        {
+            menu.AddDisabledItem(new GUIContent("无可用预设"));
+        }
+        else
+        {
+            var so = serializedObject;
+            var propertyPath = presetProp.propertyPath;
+            foreach (var option in options)
+            {
+                var capturedOption = option;
+                bool isCurrent = presetProp.objectReferenceValue == capturedOption.Preset;
+                menu.AddItem(new GUIContent(capturedOption.Name), isCurrent, () =>
+                {
+                    so.Update();
+                    var targetProp = so.FindProperty(propertyPath);
+                    if (targetProp != null)
+                    {
+                        targetProp.objectReferenceValue = capturedOption.Preset;
+                        so.ApplyModifiedProperties();
+                    }
+                });
+            }
+
+            menu.AddSeparator("");
+            menu.AddItem(new GUIContent("清除引用"), presetProp.objectReferenceValue == null, () =>
+            {
+                so.Update();
+                var targetProp = so.FindProperty(propertyPath);
+                if (targetProp != null)
+                {
+                    targetProp.objectReferenceValue = null;
+                    so.ApplyModifiedProperties();
+                }
+            });
+        }
+
+        menu.ShowAsContext();
+    }
+}
+#endif

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/Editor/UIStateMachineEditor.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/Editor/UIStateMachineEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88c9509fbcea4b338d7c67b5f4d8260b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b64ed8e5414148508136207b5513900b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenEditorUtility.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenEditorUtility.cs
@@ -1,0 +1,67 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+
+internal readonly struct UITweenPresetOption
+{
+    public string Name { get; }
+    public UITweenPreset Preset { get; }
+
+    public UITweenPresetOption(string name, UITweenPreset preset)
+    {
+        Name = name;
+        Preset = preset;
+    }
+}
+
+internal static class UITweenEditorUtility
+{
+    public static List<UITweenPresetOption> GetPresetOptions(UITweenPlayer player)
+    {
+        var options = new List<UITweenPresetOption>();
+        if (player == null)
+        {
+            return options;
+        }
+
+        var seenNames = new HashSet<string>(StringComparer.Ordinal);
+
+        void AddPreset(UITweenPreset preset)
+        {
+            if (preset == null)
+            {
+                return;
+            }
+
+            string displayName = string.IsNullOrEmpty(preset.presetName) ? preset.name : preset.presetName;
+            if (!seenNames.Add(displayName))
+            {
+                return;
+            }
+
+            options.Add(new UITweenPresetOption(displayName, preset));
+        }
+
+        foreach (var preset in player.presets)
+        {
+            AddPreset(preset);
+        }
+
+        foreach (var library in player.libraries)
+        {
+            if (library == null)
+            {
+                continue;
+            }
+
+            foreach (var preset in library.items)
+            {
+                AddPreset(preset);
+            }
+        }
+
+        options.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.Ordinal));
+        return options;
+    }
+}
+#endif

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenEditorUtility.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenEditorUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4f4ed298f144fbfabee6c2a909c3f74
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenTrackEditor.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenTrackEditor.cs
@@ -1,0 +1,218 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+[CustomEditor(typeof(UITweenTrack))]
+public class UITweenTrackEditor : Editor
+{
+    SerializedProperty _tracksProp;
+    SerializedProperty _useUnscaledProp;
+
+    void OnEnable()
+    {
+        _tracksProp = serializedObject.FindProperty("tracks");
+        _useUnscaledProp = serializedObject.FindProperty("useUnscaledIntervals");
+    }
+
+    public override void OnInspectorGUI()
+    {
+        if (serializedObject.isEditingMultipleObjects)
+        {
+            EditorGUILayout.HelpBox("暂不支持多对象同时编辑 UITweenTrack。", MessageType.Info);
+            return;
+        }
+
+        serializedObject.Update();
+
+        EditorGUILayout.PropertyField(_useUnscaledProp);
+        EditorGUILayout.Space();
+
+        DrawTracks();
+
+        serializedObject.ApplyModifiedProperties();
+    }
+
+    void DrawTracks()
+    {
+        EditorGUILayout.LabelField("轨道设置", EditorStyles.boldLabel);
+        if (_tracksProp == null)
+        {
+            EditorGUILayout.HelpBox("未找到轨道数据。", MessageType.Warning);
+            return;
+        }
+
+        for (int i = 0; i < _tracksProp.arraySize; i++)
+        {
+            var trackProp = _tracksProp.GetArrayElementAtIndex(i);
+            using (new EditorGUILayout.VerticalScope("box"))
+            {
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    EditorGUILayout.PropertyField(trackProp.FindPropertyRelative("trackName"), new GUIContent("轨道名称"));
+                    if (GUILayout.Button("删除", GUILayout.Width(50f)))
+                    {
+                        _tracksProp.DeleteArrayElementAtIndex(i);
+                        break;
+                    }
+                }
+
+                var intervalProp = trackProp.FindPropertyRelative("uniformInterval");
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    EditorGUILayout.PropertyField(intervalProp, new GUIContent("统一间隔"));
+                    if (GUILayout.Button("应用到轨道", GUILayout.Width(100f)))
+                    {
+                        ApplyUniformInterval(i, intervalProp.floatValue);
+                    }
+                }
+
+                DrawTrackItems(trackProp, i);
+            }
+        }
+
+        if (GUILayout.Button("添加新轨道"))
+        {
+            _tracksProp.arraySize++;
+        }
+    }
+
+    void DrawTrackItems(SerializedProperty trackProp, int trackIndex)
+    {
+        var itemsProp = trackProp.FindPropertyRelative("items");
+        if (itemsProp == null)
+        {
+            EditorGUILayout.HelpBox("轨道元素数据缺失。", MessageType.Warning);
+            return;
+        }
+
+        EditorGUILayout.LabelField("轨道元素", EditorStyles.boldLabel);
+
+        for (int j = 0; j < itemsProp.arraySize; j++)
+        {
+            var itemProp = itemsProp.GetArrayElementAtIndex(j);
+            using (new EditorGUILayout.VerticalScope("box"))
+            {
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    EditorGUILayout.LabelField($"元素 {j + 1}", EditorStyles.boldLabel);
+                    GUILayout.FlexibleSpace();
+                    using (new EditorGUI.DisabledScope(j <= 0))
+                    {
+                        if (GUILayout.Button("↑", GUILayout.Width(24f)))
+                        {
+                            itemsProp.MoveArrayElement(j, j - 1);
+                            break;
+                        }
+                    }
+
+                    using (new EditorGUI.DisabledScope(j >= itemsProp.arraySize - 1))
+                    {
+                        if (GUILayout.Button("↓", GUILayout.Width(24f)))
+                        {
+                            itemsProp.MoveArrayElement(j, j + 1);
+                            break;
+                        }
+                    }
+
+                    if (GUILayout.Button("删除", GUILayout.Width(50f)))
+                    {
+                        itemsProp.DeleteArrayElementAtIndex(j);
+                        break;
+                    }
+                }
+
+                var playerProp = itemProp.FindPropertyRelative("player");
+                EditorGUILayout.PropertyField(playerProp, new GUIContent("UI Tween Player"));
+
+                var player = playerProp.objectReferenceValue as UITweenPlayer;
+                IReadOnlyList<UITweenPresetOption> options = UITweenEditorUtility.GetPresetOptions(player);
+
+                DrawPresetNameSelector(itemProp.FindPropertyRelative("presetName"), options);
+                EditorGUILayout.PropertyField(itemProp.FindPropertyRelative("delayAfterPlay"), new GUIContent("播放间隔"));
+            }
+        }
+
+        if (GUILayout.Button("添加元素"))
+        {
+            itemsProp.arraySize++;
+        }
+    }
+
+    void DrawPresetNameSelector(SerializedProperty presetProp, IReadOnlyList<UITweenPresetOption> options)
+    {
+        if (presetProp == null)
+        {
+            return;
+        }
+
+        using (new EditorGUILayout.HorizontalScope())
+        {
+            EditorGUILayout.PropertyField(presetProp, new GUIContent("播放名称"));
+            using (new EditorGUI.DisabledScope(options == null || options.Count == 0))
+            {
+                if (GUILayout.Button("库中选择", GUILayout.Width(80f)))
+                {
+                    ShowPresetNameMenu(presetProp, options);
+                }
+            }
+        }
+    }
+
+    void ShowPresetNameMenu(SerializedProperty presetProp, IReadOnlyList<UITweenPresetOption> options)
+    {
+        var menu = new GenericMenu();
+        if (options == null || options.Count == 0)
+        {
+            menu.AddDisabledItem(new GUIContent("无可用预设"));
+        }
+        else
+        {
+            var so = serializedObject;
+            var propertyPath = presetProp.propertyPath;
+            foreach (var option in options)
+            {
+                var capturedName = option.Name;
+                menu.AddItem(new GUIContent(capturedName), string.Equals(capturedName, presetProp.stringValue, StringComparison.Ordinal), () =>
+                {
+                    so.Update();
+                    var targetProp = so.FindProperty(propertyPath);
+                    if (targetProp != null)
+                    {
+                        targetProp.stringValue = capturedName;
+                        so.ApplyModifiedProperties();
+                    }
+                });
+            }
+
+            menu.AddSeparator("");
+            menu.AddItem(new GUIContent("清空名称"), string.IsNullOrEmpty(presetProp.stringValue), () =>
+            {
+                so.Update();
+                var targetProp = so.FindProperty(propertyPath);
+                if (targetProp != null)
+                {
+                    targetProp.stringValue = string.Empty;
+                    so.ApplyModifiedProperties();
+                }
+            });
+        }
+
+        menu.ShowAsContext();
+    }
+
+    void ApplyUniformInterval(int trackIndex, float interval)
+    {
+        foreach (var obj in targets)
+        {
+            if (obj is UITweenTrack track)
+            {
+                Undo.RecordObject(track, "Apply Uniform Interval");
+                track.ApplyUniformInterval(trackIndex, interval);
+                EditorUtility.SetDirty(track);
+            }
+        }
+    }
+}
+#endif

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenTrackEditor.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenTrackEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bafb9910322842b491ee9da3d90b9bf7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenTrack.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenTrack.cs
@@ -1,0 +1,144 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 轻量化的轨道播放器，用于顺序触发多个 <see cref="UITweenPlayer"/>。
+/// </summary>
+[DisallowMultipleComponent]
+public class UITweenTrack : MonoBehaviour
+{
+    [System.Serializable]
+    public class TrackItem
+    {
+        [Tooltip("需要播放动画的 UI 对象，必须带有 UITweenPlayer 组件。")]
+        public UITweenPlayer player;
+
+        [Tooltip("在 Library 中的动画名称，仅支持按名称播放。")]
+        public string presetName;
+
+        [Tooltip("该动画播放完毕后的间隔，单位：秒。")]
+        public float delayAfterPlay = 0.1f;
+    }
+
+    [System.Serializable]
+    public class Track
+    {
+        [Tooltip("轨道名称，仅用于标识。")]
+        public string trackName;
+
+        [Tooltip("为该轨道全部元素统一设置的播放间隔。点击“应用到轨道”按钮后生效。")]
+        public float uniformInterval = 0.1f;
+
+        [Tooltip("轨道包含的元素，添加顺序即播放顺序。")]
+        public List<TrackItem> items = new List<TrackItem>();
+
+        public void ApplyUniformInterval(float interval)
+        {
+            uniformInterval = Mathf.Max(0f, interval);
+            foreach (var item in items)
+            {
+                if (item == null) continue;
+                item.delayAfterPlay = uniformInterval;
+            }
+        }
+    }
+
+    [Tooltip("轨道集合，可自由增删。")]
+    public List<Track> tracks = new List<Track>();
+
+    [Tooltip("播放间隔是否使用真实时间（忽略 TimeScale）。")]
+    public bool useUnscaledIntervals = true;
+
+    readonly Dictionary<int, Coroutine> _runningTracks = new();
+
+    public void PlayTrackByIndex_Event(int trackIndex)
+    {
+        PlayTrack(trackIndex);
+    }
+
+    public void PlayTrackByName(string trackName)
+    {
+        if (string.IsNullOrEmpty(trackName)) return;
+
+        for (int i = 0; i < tracks.Count; i++)
+        {
+            if (tracks[i] != null && tracks[i].trackName == trackName)
+            {
+                PlayTrack(i);
+                return;
+            }
+        }
+    }
+
+    public void PlayTrack(int trackIndex)
+    {
+        if (!isActiveAndEnabled) return;
+        if (trackIndex < 0 || trackIndex >= tracks.Count) return;
+
+        StopTrack(trackIndex);
+        var track = tracks[trackIndex];
+        if (track == null) return;
+
+        var routine = StartCoroutine(RunTrack(trackIndex, track));
+        _runningTracks[trackIndex] = routine;
+    }
+
+    public void StopTrack(int trackIndex)
+    {
+        if (_runningTracks.TryGetValue(trackIndex, out var routine) && routine != null)
+        {
+            StopCoroutine(routine);
+        }
+        _runningTracks.Remove(trackIndex);
+    }
+
+    public void StopAllTracks()
+    {
+        foreach (var routine in _runningTracks.Values)
+        {
+            if (routine != null)
+            {
+                StopCoroutine(routine);
+            }
+        }
+        _runningTracks.Clear();
+    }
+
+    public void ApplyUniformInterval(int trackIndex, float interval)
+    {
+        if (trackIndex < 0 || trackIndex >= tracks.Count) return;
+        var track = tracks[trackIndex];
+        track?.ApplyUniformInterval(interval);
+    }
+
+    IEnumerator RunTrack(int trackIndex, Track track)
+    {
+        foreach (var item in track.items)
+        {
+            if (item == null || item.player == null) continue;
+
+            item.player.PlayMasterByName(item.presetName);
+
+            float waitDuration = Mathf.Max(0f, item.delayAfterPlay);
+            if (waitDuration > 0f)
+            {
+                if (useUnscaledIntervals)
+                {
+                    yield return new WaitForSecondsRealtime(waitDuration);
+                }
+                else
+                {
+                    yield return new WaitForSeconds(waitDuration);
+                }
+            }
+        }
+
+        _runningTracks.Remove(trackIndex);
+    }
+
+    void OnDisable()
+    {
+        StopAllTracks();
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenTrack.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenTrack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: abef3c196b634641a240cb1806424b65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add a shared editor utility to collect preset options from UITweenPlayer libraries
- upgrade the UITweenTrack inspector with per-item preset pickers and track management controls
- create a custom UIStateMachine inspector that offers the same preset selection workflow

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68eb06ff32e48329bd64e623671fb319