### PR TITLE
Ensure UITween track playback is sequential

### DIFF
--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenTrack.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenTrack.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using DG.Tweening;
 using UnityEngine;
 
 /// <summary>
@@ -118,7 +119,12 @@ public class UITweenTrack : MonoBehaviour
         {
             if (item == null || item.player == null) continue;
 
-            item.player.PlayMasterByName(item.presetName);
+            var tween = item.player.PlayMasterByName(item.presetName);
+
+            if (tween != null)
+            {
+                yield return tween.WaitForCompletion();
+            }
 
             float waitDuration = Mathf.Max(0f, item.delayAfterPlay);
             if (waitDuration > 0f)


### PR DESCRIPTION
## Summary
- make UITweenTrack wait for each tween to complete before advancing to the next item
- add the required DG.Tweening namespace import so the track can access Tween helpers

## Testing
- not run (editor scripts only)


------
https://chatgpt.com/codex/tasks/task_e_68eb11fffb7c83299d6b387e30bff6c6