### PR TITLE
feat: build pushdown UI router system

### DIFF
--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/Editor/UIStateMachineEditor.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/Editor/UIStateMachineEditor.cs
@@ -8,11 +8,17 @@ public class UIStateMachineEditor : Editor
 {
     SerializedProperty _stateAnimationsProp;
     SerializedProperty _startingStateProp;
+    SerializedProperty _defaultProfileIdProp;
+    SerializedProperty _additionalProfilesProp;
+    SerializedProperty _layerProfilesProp;
 
     void OnEnable()
     {
         _stateAnimationsProp = serializedObject.FindProperty("stateAnimations");
         _startingStateProp = serializedObject.FindProperty("startingState");
+        _defaultProfileIdProp = serializedObject.FindProperty("defaultProfileId");
+        _additionalProfilesProp = serializedObject.FindProperty("additionalProfiles");
+        _layerProfilesProp = serializedObject.FindProperty("layerProfiles");
     }
 
     public override void OnInspectorGUI()
@@ -25,10 +31,15 @@ public class UIStateMachineEditor : Editor
 
         serializedObject.Update();
 
-        EditorGUILayout.PropertyField(_startingStateProp, new GUIContent("初始状态"));
+        EditorGUILayout.PropertyField(_defaultProfileIdProp, new GUIContent("默认 Profile Id"));
+        EditorGUILayout.PropertyField(_startingStateProp, new GUIContent("默认 Profile 初始状态"));
         EditorGUILayout.Space();
 
         DrawStateBindings();
+
+        EditorGUILayout.Space();
+        EditorGUILayout.PropertyField(_additionalProfilesProp, new GUIContent("额外 Profiles"), true);
+        EditorGUILayout.PropertyField(_layerProfilesProp, new GUIContent("层级 Profile 映射"), true);
 
         serializedObject.ApplyModifiedProperties();
     }
@@ -48,7 +59,7 @@ public class UIStateMachineEditor : Editor
             EditorGUILayout.HelpBox("当前 UITweenPlayer 未关联任何预设或库，暂无可选项。", MessageType.Info);
         }
 
-        EditorGUILayout.LabelField("状态动画绑定", EditorStyles.boldLabel);
+        EditorGUILayout.LabelField("默认 Profile 状态动画绑定", EditorStyles.boldLabel);
 
         if (_stateAnimationsProp == null)
         {

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIHierarchyLayerManager.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIHierarchyLayerManager.cs
@@ -1,0 +1,327 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+[DisallowMultipleComponent]
+public class UIHierarchyLayerManager : MonoBehaviour
+{
+    [Header("层级设置")]
+    public UIHierarchyLevel managedLevel = UIHierarchyLevel.PrimaryMenu;
+
+    [Tooltip("默认用于播放层级切换动画的 Tween Player。")]
+    public UITweenPlayer defaultTweenPlayer;
+
+    [Tooltip("用于屏蔽下层 UI 的 CanvasGroup，可选。")]
+    public CanvasGroup raycastShield;
+
+    [Tooltip("当层级非激活时是否自动关闭射线。")]
+    public bool disableRaycastWhenInactive = true;
+
+    [Tooltip("当层级激活时是否自动打开射线。")]
+    public bool enableRaycastWhenActive = true;
+
+    [Header("过渡策略")]
+    public List<UITransitionPolicy> transitionPolicies = new();
+
+    [Header("托管对象")]
+    public List<UIManagedElement> managedElements = new();
+
+    [Header("事件")]
+    public UIRouteNodeEvent onLayerEntered;
+    public UIRouteNodeEvent onLayerLeft;
+
+    private UIRouteNode _activeNode;
+
+    private void OnEnable()
+    {
+        if (UIRouter.HasInstance)
+        {
+            UIRouter.Instance.RegisterLayerManager(this);
+        }
+    }
+
+    private void Start()
+    {
+        if (UIRouter.HasInstance)
+        {
+            UIRouter.Instance.RegisterLayerManager(this);
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (UIRouter.HasInstance)
+        {
+            UIRouter.Instance.UnregisterLayerManager(this);
+        }
+    }
+
+    internal void SyncImmediately(UIRoute snapshot)
+    {
+        var node = snapshot?.GetNode(managedLevel);
+        bool active = node != null;
+        _activeNode = node;
+        ApplyActiveState(active);
+        if (active)
+        {
+            BroadcastEntry(node);
+        }
+    }
+
+    internal void CancelActiveTransitions()
+    {
+        if (defaultTweenPlayer != null)
+        {
+            defaultTweenPlayer.Kill(false);
+        }
+
+        foreach (var element in managedElements)
+        {
+            element.KillTweens();
+        }
+    }
+
+    internal void HandleRouteWillChange(UIRouteChangeContext context)
+    {
+        var nextNode = context.NextNode(managedLevel);
+        bool willBeActive = nextNode != null;
+        if (!willBeActive)
+        {
+            ApplyRaycast(false);
+        }
+    }
+
+    internal float HandleRouteChanged(UIRouteChangeContext context)
+    {
+        var previousNode = context.PreviousNode(managedLevel);
+        var nextNode = context.NextNode(managedLevel);
+        bool wasActive = previousNode != null;
+        bool willBeActive = nextNode != null;
+
+        _activeNode = nextNode;
+
+        ApplyActiveState(willBeActive);
+
+        if (willBeActive)
+        {
+            BroadcastEntry(nextNode);
+        }
+        else if (wasActive)
+        {
+            BroadcastExit(previousNode);
+        }
+
+        return EvaluateTransition(context);
+    }
+
+    private void ApplyActiveState(bool active)
+    {
+        ApplyRaycast(active);
+
+        foreach (var element in managedElements)
+        {
+            element.ApplyProfile(managedLevel, active);
+        }
+    }
+
+    private void ApplyRaycast(bool active)
+    {
+        if (raycastShield != null)
+        {
+            raycastShield.blocksRaycasts = active;
+            raycastShield.interactable = active;
+        }
+
+        foreach (var element in managedElements)
+        {
+            if (active)
+            {
+                if (enableRaycastWhenActive)
+                {
+                    element.SetRaycast(true);
+                }
+            }
+            else if (disableRaycastWhenInactive)
+            {
+                element.SetRaycast(false);
+            }
+        }
+    }
+
+    private void BroadcastEntry(UIRouteNode node)
+    {
+        if (node == null) return;
+        if (onLayerEntered != null)
+        {
+            onLayerEntered.Invoke(node);
+        }
+    }
+
+    private void BroadcastExit(UIRouteNode node)
+    {
+        if (node == null) return;
+        if (onLayerLeft != null)
+        {
+            onLayerLeft.Invoke(node);
+        }
+    }
+
+    private float EvaluateTransition(UIRouteChangeContext context)
+    {
+        var prevHighest = context.PreviousHighest;
+        var nextHighest = context.NextHighest;
+        if (prevHighest == nextHighest)
+        {
+            return 0f;
+        }
+
+        bool reversed = false;
+        var policy = FindPolicy(prevHighest, nextHighest, out reversed);
+        if (policy == null)
+        {
+            return 0f;
+        }
+
+        var player = policy.playerOverride != null ? policy.playerOverride : defaultTweenPlayer;
+        if (player == null)
+        {
+            return 0f;
+        }
+
+        UITweenPreset preset = reversed ? policy.backwardPreset : policy.forwardPreset;
+        if (preset == null)
+        {
+            return 0f;
+        }
+
+        player.Kill(false);
+        player.Play(preset);
+
+        foreach (var element in managedElements)
+        {
+            element.NotifyTrackTriggered(player, preset);
+        }
+
+        float overrideDuration = reversed ? policy.backwardDurationOverride : policy.forwardDurationOverride;
+        if (overrideDuration > 0f)
+        {
+            return overrideDuration;
+        }
+
+        return preset != null ? Mathf.Max(0f, preset.duration) : 0f;
+    }
+
+    private UITransitionPolicy FindPolicy(UIHierarchyLevel prevHighest, UIHierarchyLevel nextHighest, out bool reversed)
+    {
+        foreach (var policy in transitionPolicies)
+        {
+            if (policy == null) continue;
+            if (policy.fromLevel == prevHighest && policy.toLevel == nextHighest)
+            {
+                reversed = false;
+                return policy;
+            }
+
+            if (policy.fromLevel == nextHighest && policy.toLevel == prevHighest)
+            {
+                reversed = true;
+                return policy;
+            }
+        }
+
+        reversed = false;
+        return null;
+    }
+}
+
+[System.Serializable]
+public class UIManagedElement
+{
+    [Tooltip("便于识别的名称，可选。")]
+    public string name;
+
+    [Tooltip("用于控制 Raycast 的 CanvasGroup，可选。")]
+    public CanvasGroup canvasGroup;
+
+    [Tooltip("关联的状态机组件，可选。")]
+    public UIStateMachine stateMachine;
+
+    [Tooltip("在本层级激活时使用的 Profile Id，留空则走状态机的层级映射。")]
+    public string profileOverrideId;
+
+    [Tooltip("激活时是否将状态机重置到 Profile 的起始状态。")]
+    public bool resetStateOnActivate = true;
+
+    [Tooltip("当层级非激活时是否自动切回默认 Profile。")]
+    public bool resetToDefaultOnDeactivate = true;
+
+    [Tooltip("额外需要 Kill 的动画播放器列表。")]
+    public List<UITweenPlayer> tweenPlayers = new();
+
+    public void ApplyProfile(UIHierarchyLevel level, bool active)
+    {
+        if (canvasGroup != null)
+        {
+            canvasGroup.blocksRaycasts = active;
+            canvasGroup.interactable = active;
+        }
+
+        if (stateMachine != null)
+        {
+            if (active)
+            {
+                if (!string.IsNullOrEmpty(profileOverrideId))
+                {
+                    stateMachine.ApplyProfile(profileOverrideId, resetStateOnActivate);
+                }
+                else
+                {
+                    bool applied = stateMachine.ApplyLevelProfile(level, resetStateOnActivate);
+                    if (!applied && resetStateOnActivate)
+                    {
+                        stateMachine.ResetToDefaultProfile(true);
+                    }
+                }
+            }
+            else if (resetToDefaultOnDeactivate)
+            {
+                stateMachine.ResetToDefaultProfile(true);
+            }
+        }
+    }
+
+    public void SetRaycast(bool enabled)
+    {
+        if (canvasGroup != null)
+        {
+            canvasGroup.blocksRaycasts = enabled;
+            canvasGroup.interactable = enabled;
+        }
+    }
+
+    public void KillTweens()
+    {
+        if (stateMachine != null)
+        {
+            stateMachine.KillActiveTween();
+        }
+
+        foreach (var player in tweenPlayers)
+        {
+            if (player != null)
+            {
+                player.Kill(false);
+            }
+        }
+    }
+
+    public void NotifyTrackTriggered(UITweenPlayer player, UITweenPreset preset)
+    {
+        // 预留扩展点：此处可根据需要同步其他动画状态。
+    }
+}
+
+[System.Serializable]
+public class UIRouteNodeEvent : UnityEvent<UIRouteNode>
+{
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIHierarchyLayerManager.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIHierarchyLayerManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 904d2246626640ae8e691d0b126f1f4f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIHierarchyLevel.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIHierarchyLevel.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+public enum UIHierarchyLevel
+{
+    None = -1,
+    MainMenu = 0,
+    GameUI = 1,
+    PrimaryMenu = 2,
+    SecondaryMenu = 3,
+    TertiaryMenu = 4,
+}
+
+public static class UIHierarchyLevelUtility
+{
+    public const UIHierarchyLevel Lowest = UIHierarchyLevel.MainMenu;
+    public const UIHierarchyLevel Highest = UIHierarchyLevel.TertiaryMenu;
+
+    public static bool IsWithinBounds(this UIHierarchyLevel level)
+    {
+        return level >= Lowest && level <= Highest;
+    }
+
+    public static bool TryGetNext(UIHierarchyLevel current, out UIHierarchyLevel next)
+    {
+        int candidate = (int)current + 1;
+        if (candidate > (int)Highest)
+        {
+            next = Highest;
+            return false;
+        }
+
+        next = (UIHierarchyLevel)candidate;
+        return true;
+    }
+
+    public static IEnumerable<UIHierarchyLevel> EnumerateFrom(UIHierarchyLevel start)
+    {
+        for (int level = (int)start; level <= (int)Highest; level++)
+        {
+            yield return (UIHierarchyLevel)level;
+        }
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIHierarchyLevel.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIHierarchyLevel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d9f17bdb78d54bf3bda8d963fa0a931a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRoute.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRoute.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Text;
+
+public class UIRoute
+{
+    private readonly Dictionary<UIHierarchyLevel, UIRouteNode> _levels = new();
+
+    public UIRoute Clone()
+    {
+        var clone = new UIRoute();
+        foreach (var pair in _levels)
+        {
+            clone._levels[pair.Key] = pair.Value;
+        }
+
+        return clone;
+    }
+
+    public void SetNode(UIHierarchyLevel level, UIRouteNode node)
+    {
+        if (node == null)
+        {
+            _levels.Remove(level);
+        }
+        else
+        {
+            _levels[level] = node;
+        }
+    }
+
+    public UIRouteNode GetNode(UIHierarchyLevel level)
+    {
+        _levels.TryGetValue(level, out var node);
+        return node;
+    }
+
+    public bool IsActive(UIHierarchyLevel level)
+    {
+        return _levels.ContainsKey(level);
+    }
+
+    public UIHierarchyLevel GetHighestLevel()
+    {
+        UIHierarchyLevel highest = UIHierarchyLevel.None;
+        foreach (var pair in _levels)
+        {
+            if ((int)pair.Key > (int)highest)
+            {
+                highest = pair.Key;
+            }
+        }
+
+        return highest;
+    }
+
+    public IEnumerable<KeyValuePair<UIHierarchyLevel, UIRouteNode>> Enumerate()
+    {
+        foreach (var pair in _levels)
+        {
+            yield return pair;
+        }
+    }
+
+    public string BuildPath(UIHierarchyLevel startLevel)
+    {
+        var sb = new StringBuilder();
+        for (int level = (int)startLevel; level <= (int)UIHierarchyLevelUtility.Highest; level++)
+        {
+            var key = (UIHierarchyLevel)level;
+            if (_levels.TryGetValue(key, out var node) && node != null)
+            {
+                if (sb.Length > 0) sb.Append('/');
+                sb.Append(node.Id);
+            }
+        }
+
+        return sb.ToString();
+    }
+}
+
+public class UIRouteNode
+{
+    public string Id { get; }
+    public object Payload { get; }
+
+    public UIRouteNode(string id, object payload = null)
+    {
+        Id = id;
+        Payload = payload;
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRoute.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRoute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5cc3869361943179c48428d6568b712
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRouteChangeContext.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRouteChangeContext.cs
@@ -1,0 +1,26 @@
+public class UIRouteChangeContext
+{
+    public UIRoute Previous { get; }
+    public UIRoute Next { get; }
+    public UIRouteCommand Command => _request.Command;
+    public string RequestedPath => _request.Path;
+    public object Payload => _request.Payload;
+    public UIHierarchyLevel StartLevel => _request.StartLevel;
+    public UIHierarchyLevel ModalLevel => _request.ModalLevel;
+
+    private readonly UIRouteRequest _request;
+
+    public UIRouteChangeContext(UIRoute previous, UIRoute next, UIRouteRequest request)
+    {
+        Previous = previous;
+        Next = next;
+        _request = request;
+    }
+
+    public bool WasActive(UIHierarchyLevel level) => Previous != null && Previous.IsActive(level);
+    public bool WillBeActive(UIHierarchyLevel level) => Next != null && Next.IsActive(level);
+    public UIRouteNode PreviousNode(UIHierarchyLevel level) => Previous?.GetNode(level);
+    public UIRouteNode NextNode(UIHierarchyLevel level) => Next?.GetNode(level);
+    public UIHierarchyLevel PreviousHighest => Previous != null ? Previous.GetHighestLevel() : UIHierarchyLevel.None;
+    public UIHierarchyLevel NextHighest => Next != null ? Next.GetHighestLevel() : UIHierarchyLevel.None;
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRouteChangeContext.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRouteChangeContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31f5a80f23a946d49d81bcf3acfc8903
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRouter.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRouter.cs
@@ -1,0 +1,323 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[DefaultExecutionOrder(-1000)]
+public class UIRouter : MonoBehaviour
+{
+    private static UIRouter _instance;
+
+    public static UIRouter Instance
+    {
+        get
+        {
+            if (_instance == null)
+            {
+                var existing = FindObjectOfType<UIRouter>();
+                if (existing != null)
+                {
+                    _instance = existing;
+                    _instance.InitializeSingleton();
+                }
+            }
+
+            return _instance;
+        }
+    }
+
+    public static bool HasInstance => Instance != null;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    private static void EnsureRouter()
+    {
+        if (_instance == null)
+        {
+            var go = new GameObject("[UIRouter]");
+            go.AddComponent<UIRouter>();
+        }
+    }
+
+    private readonly Queue<UIRouteRequest> _requestQueue = new();
+    private readonly List<UIHierarchyLayerManager> _layerManagers = new();
+    private Dictionary<UIHierarchyLevel, Stack<UIRouteNode>> _stacks = new();
+    private UIRoute _currentRoute = new();
+    private bool _isTransitioning;
+
+    public bool IsTransitioning => _isTransitioning;
+    public UIRoute CurrentRoute => _currentRoute;
+
+    public event Action<UIRouteChangeContext> OnRouteWillChange;
+    public event Action<UIRouteChangeContext> OnRouteChanged;
+
+    private void Awake()
+    {
+        if (_instance != null && _instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        _instance = this;
+        InitializeSingleton();
+    }
+
+    private void InitializeSingleton()
+    {
+        DontDestroyOnLoad(gameObject);
+        if (_stacks == null)
+        {
+            _stacks = new Dictionary<UIHierarchyLevel, Stack<UIRouteNode>>();
+        }
+
+        if (_currentRoute == null)
+        {
+            _currentRoute = new UIRoute();
+        }
+    }
+
+    public void RegisterLayerManager(UIHierarchyLayerManager manager)
+    {
+        if (manager == null) return;
+        if (_layerManagers.Contains(manager)) return;
+        _layerManagers.Add(manager);
+        manager.SyncImmediately(_currentRoute);
+    }
+
+    public void UnregisterLayerManager(UIHierarchyLayerManager manager)
+    {
+        if (manager == null) return;
+        _layerManagers.Remove(manager);
+    }
+
+    public void GoTo(string path, UIHierarchyLevel startLevel = UIHierarchyLevel.GameUI, object payload = null)
+    {
+        EnqueueRequest(new UIRouteRequest
+        {
+            Command = UIRouteCommand.Replace,
+            Path = path,
+            StartLevel = startLevel,
+            Payload = payload
+        });
+    }
+
+    public void Push(string path, UIHierarchyLevel level, object payload = null)
+    {
+        EnqueueRequest(new UIRouteRequest
+        {
+            Command = UIRouteCommand.Push,
+            Path = path,
+            ModalLevel = level,
+            Payload = payload
+        });
+    }
+
+    public void Pop(UIHierarchyLevel level)
+    {
+        EnqueueRequest(new UIRouteRequest
+        {
+            Command = UIRouteCommand.Pop,
+            ModalLevel = level
+        });
+    }
+
+    private void EnqueueRequest(UIRouteRequest request)
+    {
+        if (request == null) return;
+        _requestQueue.Enqueue(request);
+        TryProcessNext();
+    }
+
+    private void TryProcessNext()
+    {
+        if (_isTransitioning) return;
+        if (_requestQueue.Count == 0) return;
+
+        var request = _requestQueue.Dequeue();
+        StartCoroutine(ProcessRequest(request));
+    }
+
+    private IEnumerator ProcessRequest(UIRouteRequest request)
+    {
+        _isTransitioning = true;
+
+        var previousRoute = _currentRoute?.Clone() ?? new UIRoute();
+        var stacksCopy = CloneStacks();
+        ApplyRequestToStacks(stacksCopy, request);
+        var nextRoute = BuildRouteSnapshot(stacksCopy);
+
+        var context = new UIRouteChangeContext(previousRoute, nextRoute, request);
+
+        foreach (var manager in _layerManagers)
+        {
+            manager.CancelActiveTransitions();
+        }
+
+        OnRouteWillChange?.Invoke(context);
+        foreach (var manager in _layerManagers)
+        {
+            manager.HandleRouteWillChange(context);
+        }
+
+        float maxDuration = 0f;
+        foreach (var manager in _layerManagers)
+        {
+            maxDuration = Mathf.Max(maxDuration, manager.HandleRouteChanged(context));
+        }
+
+        _stacks = stacksCopy;
+        _currentRoute = nextRoute;
+
+        OnRouteChanged?.Invoke(context);
+
+        if (maxDuration > 0f)
+        {
+            yield return new WaitForSeconds(maxDuration);
+        }
+        else
+        {
+            yield return null;
+        }
+
+        _isTransitioning = false;
+        TryProcessNext();
+    }
+
+    private Dictionary<UIHierarchyLevel, Stack<UIRouteNode>> CloneStacks()
+    {
+        var copy = new Dictionary<UIHierarchyLevel, Stack<UIRouteNode>>();
+        foreach (var pair in _stacks)
+        {
+            copy[pair.Key] = new Stack<UIRouteNode>(new Stack<UIRouteNode>(pair.Value));
+        }
+
+        return copy;
+    }
+
+    private void ApplyRequestToStacks(Dictionary<UIHierarchyLevel, Stack<UIRouteNode>> stacks, UIRouteRequest request)
+    {
+        if (request == null) return;
+
+        switch (request.Command)
+        {
+            case UIRouteCommand.Replace:
+                ApplyReplace(stacks, request);
+                break;
+            case UIRouteCommand.Push:
+                ApplyPush(stacks, request);
+                break;
+            case UIRouteCommand.Pop:
+                ApplyPop(stacks, request);
+                break;
+        }
+    }
+
+    private void ApplyReplace(Dictionary<UIHierarchyLevel, Stack<UIRouteNode>> stacks, UIRouteRequest request)
+    {
+        ClearStacksFromLevel(stacks, request.StartLevel);
+
+        if (string.IsNullOrEmpty(request.Path))
+        {
+            return;
+        }
+
+        var segments = request.Path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        for (int i = 0; i < segments.Length; i++)
+        {
+            int levelValue = (int)request.StartLevel + i;
+            if (levelValue > (int)UIHierarchyLevelUtility.Highest) break;
+            var level = (UIHierarchyLevel)levelValue;
+            var node = new UIRouteNode(segments[i], i == segments.Length - 1 ? request.Payload : null);
+            var stack = GetOrCreateStack(stacks, level);
+            stack.Push(node);
+        }
+
+        ClearStacksFromLevel(stacks, NextLevel((UIHierarchyLevel)((int)request.StartLevel + segments.Length - 1)));
+    }
+
+    private void ApplyPush(Dictionary<UIHierarchyLevel, Stack<UIRouteNode>> stacks, UIRouteRequest request)
+    {
+        if (string.IsNullOrEmpty(request.Path)) return;
+        var level = request.ModalLevel.IsWithinBounds() ? request.ModalLevel : UIHierarchyLevel.PrimaryMenu;
+        var stack = GetOrCreateStack(stacks, level);
+        stack.Push(new UIRouteNode(request.Path, request.Payload));
+        ClearStacksFromLevel(stacks, NextLevel(level));
+    }
+
+    private void ApplyPop(Dictionary<UIHierarchyLevel, Stack<UIRouteNode>> stacks, UIRouteRequest request)
+    {
+        var level = request.ModalLevel.IsWithinBounds() ? request.ModalLevel : UIHierarchyLevel.PrimaryMenu;
+        if (!stacks.TryGetValue(level, out var stack) || stack.Count == 0) return;
+        stack.Pop();
+        if (stack.Count == 0)
+        {
+            stacks.Remove(level);
+        }
+
+        ClearStacksFromLevel(stacks, NextLevel(level));
+    }
+
+    private void ClearStacksFromLevel(Dictionary<UIHierarchyLevel, Stack<UIRouteNode>> stacks, UIHierarchyLevel level)
+    {
+        if (!level.IsWithinBounds())
+        {
+            return;
+        }
+
+        for (int value = (int)level; value <= (int)UIHierarchyLevelUtility.Highest; value++)
+        {
+            var key = (UIHierarchyLevel)value;
+            if (stacks.TryGetValue(key, out var stack))
+            {
+                stack.Clear();
+            }
+
+            stacks.Remove(key);
+        }
+    }
+
+    private UIHierarchyLevel NextLevel(UIHierarchyLevel level)
+    {
+        return level.TryGetNext(out var next) ? next : UIHierarchyLevelUtility.Highest;
+    }
+
+    private Stack<UIRouteNode> GetOrCreateStack(Dictionary<UIHierarchyLevel, Stack<UIRouteNode>> stacks, UIHierarchyLevel level)
+    {
+        if (!stacks.TryGetValue(level, out var stack))
+        {
+            stack = new Stack<UIRouteNode>();
+            stacks[level] = stack;
+        }
+
+        return stack;
+    }
+
+    private UIRoute BuildRouteSnapshot(Dictionary<UIHierarchyLevel, Stack<UIRouteNode>> stacks)
+    {
+        var route = new UIRoute();
+        foreach (var pair in stacks)
+        {
+            if (pair.Value.Count == 0) continue;
+            var node = pair.Value.Peek();
+            route.SetNode(pair.Key, node);
+        }
+
+        return route;
+    }
+}
+
+public enum UIRouteCommand
+{
+    Replace,
+    Push,
+    Pop
+}
+
+internal class UIRouteRequest
+{
+    public UIRouteCommand Command;
+    public string Path;
+    public object Payload;
+    public UIHierarchyLevel StartLevel = UIHierarchyLevel.GameUI;
+    public UIHierarchyLevel ModalLevel = UIHierarchyLevel.PrimaryMenu;
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRouter.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRouter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc42e949684f46fc8d41d38243b3847a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRouterSetup.md
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRouterSetup.md
@@ -1,0 +1,90 @@
+# UI 路由 / 下推式状态机使用说明
+
+本文件描述了 `UIRouter`、`UIHierarchyLayerManager` 以及改进版 `UIStateMachine` 的整体协作方式，以及示例菜单配置策略。
+
+## 核心结构
+
+- **UIRouter**：全局单例（`[UIRouter]`）负责维护层级路由（MainMenu → GameUI → Primary → Secondary → Tertiary）与模态下推栈。使用 `DontDestroyOnLoad`，在场景切换时依旧保持。
+- **UIHierarchyLayerManager**：挂在具体的 Canvas/面板上。每个层级一个管理器，需手动配置本层可控制的 UI 对象、过渡策略、模态射线屏蔽。支持复合层级（一个元素被多个管理器托管）。
+- **UIStateMachine**：按钮/元素级动画状态机，现已支持 Profile 与层级映射，可根据所处层级切换不同的动画绑定。
+
+## 路由层级（默认）
+
+| 枚举值              | 含义               |
+| ------------------- | ------------------ |
+| `MainMenu`          | 主菜单（游戏初始界面） |
+| `GameUI`            | 游戏 HUD（进行中界面） |
+| `PrimaryMenu`       | 一级菜单（暂停/大面板） |
+| `SecondaryMenu`     | 二级菜单（设置、读档等） |
+| `TertiaryMenu`      | 三级菜单（确认弹窗等） |
+
+> 可根据需要扩展，但建议保持「越往下层级值越大」。
+
+## 典型配置示例
+
+1. **创建全局路由器**：无需手动添加，`UIRouter` 会在 `BeforeSceneLoad` 自动生成。若需手动配置，可在场景中放置一个空物体并挂上 `UIRouter` 组件。
+2. **GameUI 层管理器**：在游戏 HUD 根 Canvas 上添加 `UIHierarchyLayerManager`，`managedLevel` 设为 `GameUI`，配置默认 Tween Player、托管所有 HUD 元素。
+3. **PrimaryMenu（暂停面板）**：为暂停面板根节点添加管理器，设为 `PrimaryMenu`。配置 `transitionPolicies`：
+   - `fromLevel=GameUI`、`toLevel=PrimaryMenu` → 进入暂停面板播放 Track1。
+   - `fromLevel=PrimaryMenu`、`toLevel=GameUI` → 退出暂停播放 Track1 的反向。
+   - `fromLevel=PrimaryMenu`、`toLevel=SecondaryMenu` → 一级菜单退到背景播放 Track2（例如模糊）。
+4. **SecondaryMenu（设置、读档等）**：为设置面板等二级界面添加管理器；可让其在 `from=PrimaryMenu → to=SecondaryMenu` 时播放入场 Track、在回退时播放离场 Track。
+5. **TertiaryMenu（弹窗）**：常见用法是所有弹窗共用一个管理器，`transitionPolicies` 负责定义从 `SecondaryMenu`/`PrimaryMenu` 入栈时的动画。
+
+## 托管元素配置
+
+- `UIManagedElement.canvasGroup`：用于自动开关射线、交互；当层级不是当前栈顶时会被禁用。
+- `profileOverrideId`：指定该元素在本层级应使用的 `UIStateMachine` Profile；留空则根据 `UIStateMachine.layerProfiles` 自动匹配。
+- `resetStateOnActivate`：进入层级时是否把状态机重置到 Profile 定义的起始状态。
+- `tweenPlayers`：额外需要在路由切换前 Kill 的动画播放器，防止残留动画。
+
+## UIStateMachine Profile 配置
+
+1. `stateAnimations` + `startingState`：默认 Profile 的绑定，沿用旧版本配置。
+2. `additionalProfiles`：新增的 Profile 列表，每个 Profile 拥有独立的 `startingState` 与状态绑定。
+3. `layerProfiles`：层级 → Profile Id 的映射；当管理器激活该层级时，调用 `ApplyLevelProfile` 自动切换动画表现。
+
+示例：同一按钮在 `GameUI` 里使用常规高亮，在 `PrimaryMenu` 中使用弱化版动效，可将按钮的 `UIStateMachine`：
+- 默认 Profile：GameUI 样式。
+- 新建 Profile：`profileId = "PrimaryDimmed"`，绑定较弱的动画。
+- `layerProfiles` 添加一条 `{ level = PrimaryMenu, profileId = "PrimaryDimmed" }`。
+
+## 编程接口速览
+
+```csharp
+UIRouter.Instance.GoTo("Game", UIHierarchyLevel.GameUI);                 // 切换到游戏 HUD
+UIRouter.Instance.GoTo("Pause/Settings", UIHierarchyLevel.PrimaryMenu); // 深链路由：暂停 → 设置
+UIRouter.Instance.Push("Confirm", UIHierarchyLevel.TertiaryMenu);       // 压入模态弹窗
+UIRouter.Instance.Pop(UIHierarchyLevel.TertiaryMenu);                    // 关闭弹窗
+```
+
+- 所有请求都会排队执行，`UIRouter.IsTransitioning` 为 `true` 时仍可安全排队。
+- 每次切换前，路由器会调用 `Kill(false)`，防止 Tween 残留；如需打断立即进入下一个状态，可在对应 `transitionPolicies` 中设置期望时长。
+
+## 深链路由（Deep Link）
+
+- `UIRouter.GoTo("Settings/Audio", UIHierarchyLevel.PrimaryMenu, payload)`：从任意界面直接跳到二级「设置/音频」。
+- 传入的 `payload` 会绑定在最深层级（示例中为 `Audio`），可在对应 `UIHierarchyLayerManager.onLayerEntered` 中读取。
+
+## 射线屏蔽
+
+- `UIHierarchyLayerManager.raycastShield` 可指向一个全屏透明 `CanvasGroup`，用于在模态层激活时阻止下层响应。
+- 若 UI 元素自身存在 `CanvasGroup`，可将其拖入 `UIManagedElement.canvasGroup`，系统会在非当前层级时自动关闭 `blocksRaycasts` 与 `interactable`。
+
+## 推荐的层级管理器组合
+
+| 管理器 | managedLevel       | 说明 |
+| ------ | ------------------ | ---- |
+| Main   | `MainMenu`         | 负责开场主界面、Logo、开始按钮。 |
+| Game   | `GameUI`           | 负责 HUD、战斗 UI、交互提示。 |
+| Pause  | `PrimaryMenu`      | 负责暂停/背包等大面板。 |
+| Sub    | `SecondaryMenu`    | 负责设置、存档、角色面板等子页面。 |
+| Modal  | `TertiaryMenu`     | 负责确认弹窗、提示对话框等最上层模态。 |
+
+> 可根据项目实际情况拆分多个 Secondary/Tertiary 管理器（例如设置、读档各一个），互相之间不会互斥，但建议保持同一层级仅有一个处于激活状态。
+
+## 注意事项
+
+- 若需手动抢占动画控制，可直接调用 `UIManagedElement.tweenPlayers` 中的 `UITweenPlayer.PlayMaster`，框架不会阻止。
+- 推荐在 `transitionPolicies` 中维护统一命名的 Track，方便策划配置（例如 `Pause_Enter`, `Pause_Blur`, `Modal_Pop`）。
+- 若存在特殊路由（例如从主菜单直接跳读档界面），可组合 `GoTo("MainMenu")` 与 `Push` 请求实现。

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRouterSetup.md.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIRouterSetup.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5411c020f78847e6964eb254d686da06
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIStateMachine.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UIStateMachine.cs
@@ -1,42 +1,118 @@
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using System.Collections.Generic;
-using System.Linq;
 
 [RequireComponent(typeof(UITweenPlayer))]
 public class UIStateMachine : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerDownHandler, IPointerUpHandler
 {
-    // 在 Inspector 中配置所有状态的动画
-    public List<StateAnimationBinding> stateAnimations = new List<StateAnimationBinding>();
+    [Header("默认 Profile")]
+    [SerializeField] private List<StateAnimationBinding> stateAnimations = new();
+    [SerializeField] private UIState startingState = UIState.Normal;
+    [SerializeField] private string defaultProfileId = "default";
 
-    // 初始状态
-    public UIState startingState = UIState.Normal;
-    
+    [Header("额外 Profile")]
+    public List<UIStateMachineProfile> additionalProfiles = new();
+
+    [Header("层级映射")]
+    public List<UIStateMachineLayerProfile> layerProfiles = new();
+
     private UIState _currentState;
     private UITweenPlayer _tweenPlayer;
-    private Dictionary<UIState, StateAnimationBinding> _bindingMap;
+    private readonly Dictionary<string, ProfileRuntimeData> _profiles = new();
+    private ProfileRuntimeData _activeProfile;
+    private string _activeProfileId;
 
-    void Awake()
+    private void Awake()
     {
         _tweenPlayer = GetComponent<UITweenPlayer>();
-        
-        // 将 List 转换为字典，方便快速查找
-        _bindingMap = stateAnimations.ToDictionary(b => b.state, b => b);
+        BuildProfiles();
     }
 
-    void Start()
+    private void Start()
     {
-        // 初始化到起始状态，但不播放动画
-        _currentState = startingState;
+        EnsureActiveProfile();
+        if (_activeProfile != null)
+        {
+            _currentState = _activeProfile.startingState;
+        }
     }
 
-    // ---- 核心：状态转换方法 ----
+    private void BuildProfiles()
+    {
+        _profiles.Clear();
+
+        if (string.IsNullOrEmpty(defaultProfileId))
+        {
+            defaultProfileId = "default";
+        }
+
+        var defaultRuntime = BuildRuntimeData(stateAnimations, startingState);
+        _profiles[defaultProfileId] = defaultRuntime;
+
+        foreach (var profile in additionalProfiles)
+        {
+            if (profile == null) continue;
+            if (string.IsNullOrEmpty(profile.profileId)) continue;
+            _profiles[profile.profileId] = BuildRuntimeData(profile.stateAnimations, profile.startingState);
+        }
+
+        if (!_profiles.TryGetValue(defaultProfileId, out _activeProfile))
+        {
+            foreach (var pair in _profiles)
+            {
+                _activeProfileId = pair.Key;
+                _activeProfile = pair.Value;
+                break;
+            }
+        }
+        else
+        {
+            _activeProfileId = defaultProfileId;
+        }
+    }
+
+    private static ProfileRuntimeData BuildRuntimeData(List<StateAnimationBinding> bindings, UIState startState)
+    {
+        var dict = new Dictionary<UIState, StateAnimationBinding>();
+        if (bindings != null)
+        {
+            foreach (var binding in bindings)
+            {
+                if (binding == null) continue;
+                dict[binding.state] = binding;
+            }
+        }
+
+        return new ProfileRuntimeData
+        {
+            startingState = startState,
+            bindings = dict
+        };
+    }
+
+    private void EnsureActiveProfile()
+    {
+        if (_activeProfile == null)
+        {
+            BuildProfiles();
+            if (!_profiles.TryGetValue(defaultProfileId, out _activeProfile))
+            {
+                _activeProfile = BuildRuntimeData(stateAnimations, startingState);
+                _profiles[defaultProfileId] = _activeProfile;
+                _activeProfileId = defaultProfileId;
+            }
+        }
+    }
+
     private void TransitionTo(UIState newState)
     {
+        EnsureActiveProfile();
         if (_currentState == newState) return;
 
-        // 1. 播放“退出旧状态”的动画
-        if (_bindingMap.TryGetValue(_currentState, out var oldBinding))
+        var bindings = _activeProfile.bindings;
+        if (bindings == null) return;
+
+        if (bindings.TryGetValue(_currentState, out var oldBinding) && oldBinding != null)
         {
             if (oldBinding.reverseOnExit && oldBinding.onEnterPreset != null)
             {
@@ -47,9 +123,8 @@ public class UIStateMachine : MonoBehaviour, IPointerEnterHandler, IPointerExitH
                 _tweenPlayer.Play(oldBinding.onExitPreset);
             }
         }
-        
-        // 2. 播放“进入新状态”的动画
-        if (_bindingMap.TryGetValue(newState, out var newBinding))
+
+        if (bindings.TryGetValue(newState, out var newBinding) && newBinding != null)
         {
             if (newBinding.onEnterPreset != null)
             {
@@ -57,11 +132,9 @@ public class UIStateMachine : MonoBehaviour, IPointerEnterHandler, IPointerExitH
             }
         }
 
-        // 3. 更新当前状态
         _currentState = newState;
     }
 
-    // ---- UI 事件监听与状态决策 ----
     public void OnPointerEnter(PointerEventData eventData)
     {
         if (_currentState == UIState.Pressed || _currentState == UIState.Disabled) return;
@@ -82,7 +155,6 @@ public class UIStateMachine : MonoBehaviour, IPointerEnterHandler, IPointerExitH
 
     public void OnPointerUp(PointerEventData eventData)
     {
-        // 当鼠标抬起时，要判断指针是否还在对象上
         if (_currentState == UIState.Pressed)
         {
             if (eventData.pointerCurrentRaycast.gameObject == gameObject)
@@ -95,14 +167,11 @@ public class UIStateMachine : MonoBehaviour, IPointerEnterHandler, IPointerExitH
             }
         }
     }
-    
-    // ---- 外部控制接口 (例如：用于Toggle) ----
+
     public void SetSelected(bool isSelected)
     {
         if (isSelected)
         {
-            // 这里可以处理更复杂的状态组合，例如进入 "Selected" 状态
-            // 暂时简化处理
             if (_currentState != UIState.Selected) TransitionTo(UIState.Selected);
         }
         else
@@ -110,4 +179,68 @@ public class UIStateMachine : MonoBehaviour, IPointerEnterHandler, IPointerExitH
             if (_currentState == UIState.Selected) TransitionTo(UIState.Normal);
         }
     }
+
+    public bool ApplyProfile(string profileId, bool resetState = true)
+    {
+        EnsureActiveProfile();
+        if (string.IsNullOrEmpty(profileId)) return false;
+        if (!_profiles.TryGetValue(profileId, out var profile)) return false;
+        _activeProfile = profile;
+        _activeProfileId = profileId;
+        if (resetState)
+        {
+            _currentState = profile.startingState;
+        }
+        return true;
+    }
+
+    public bool ApplyLevelProfile(UIHierarchyLevel level, bool resetState = true)
+    {
+        foreach (var mapping in layerProfiles)
+        {
+            if (mapping == null) continue;
+            if (mapping.level == level && !string.IsNullOrEmpty(mapping.profileId))
+            {
+                return ApplyProfile(mapping.profileId, resetState);
+            }
+        }
+
+        return false;
+    }
+
+    public void ResetToDefaultProfile(bool resetState = true)
+    {
+        ApplyProfile(defaultProfileId, resetState);
+    }
+
+    public void KillActiveTween()
+    {
+        if (_tweenPlayer != null)
+        {
+            _tweenPlayer.Kill(false);
+        }
+    }
+
+    public string ActiveProfileId => _activeProfileId;
+
+    private class ProfileRuntimeData
+    {
+        public UIState startingState;
+        public Dictionary<UIState, StateAnimationBinding> bindings;
+    }
+}
+
+[System.Serializable]
+public class UIStateMachineProfile
+{
+    public string profileId = "profile";
+    public UIState startingState = UIState.Normal;
+    public List<StateAnimationBinding> stateAnimations = new();
+}
+
+[System.Serializable]
+public class UIStateMachineLayerProfile
+{
+    public UIHierarchyLevel level = UIHierarchyLevel.GameUI;
+    public string profileId;
 }

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UITransitionPolicy.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UITransitionPolicy.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+[System.Serializable]
+public class UITransitionPolicy
+{
+    [Tooltip("路由最高层级从此层级切换到 ToLevel 时触发正向动画。")]
+    public UIHierarchyLevel fromLevel = UIHierarchyLevel.GameUI;
+
+    [Tooltip("路由最高层级切换到此层级时触发正向动画。")]
+    public UIHierarchyLevel toLevel = UIHierarchyLevel.PrimaryMenu;
+
+    [Tooltip("当匹配 from->to 时播放的动画预设。")]
+    public UITweenPreset forwardPreset;
+
+    [Tooltip("正向动画时使用的自定义时长（<=0 使用预设时长）。")]
+    public float forwardDurationOverride = -1f;
+
+    [Tooltip("当路由最高层级从 ToLevel 回到 FromLevel 时播放的动画预设。")]
+    public UITweenPreset backwardPreset;
+
+    [Tooltip("反向动画时使用的自定义时长（<=0 使用预设时长）。")]
+    public float backwardDurationOverride = -1f;
+
+    [Tooltip("优先使用此播放器触发动画，留空则使用管理器默认播放器。")]
+    public UITweenPlayer playerOverride;
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UITransitionPolicy.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/动画管理状态机/UITransitionPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87d93948e90b4c9ead87fc8e2e86f9b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add a global UIRouter with queued pushdown routing, stack management, and deep-link helpers
- introduce UIHierarchyLayerManager with transition policies, raycast control, and managed UI state machines
- extend UIStateMachine with profile overrides and per-layer configuration, plus author usage documentation

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68eb563e1d2483298789f2316fb4010b