### PR TITLE
Add node activation filtering for UI supervision

### DIFF
--- a/ITC/Assets/Scripts/UIRouter/UIHierarchyLayerManager.cs
+++ b/ITC/Assets/Scripts/UIRouter/UIHierarchyLayerManager.cs
@@ -1,0 +1,72 @@
+using System;
+using UnityEngine;
+
+namespace ITC.UIRouter
+{
+    /// <summary>
+    /// Controls activation of UI hierarchy layers based on the upcoming route state.
+    /// </summary>
+    public class UIHierarchyLayerManager : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("The hierarchy level managed by this component.")]
+        private int managedLevel;
+
+        public enum NodeActivationFilter { Any, MatchExactId, MatchPrefix }
+
+        [Header("节点过滤")]
+        [Tooltip("Any=只要本层有节点就激活；MatchExactId/MatchPrefix=仅当节点Id匹配时才激活")]
+        public NodeActivationFilter activationFilter = NodeActivationFilter.Any;
+
+        [Tooltip("用于匹配的节点 Id 或前缀（如 Settings 或 Settings/）")]
+        public string nodeIdOrPrefix;
+
+        public event Action<UIRouteNode, UIRouteChangeContext> LayerActivated;
+        public event Action<UIRouteChangeContext> LayerDeactivated;
+
+        public void HandleRouteChanged(UIRouteChangeContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var nextNode = context.NextNode(managedLevel);
+            bool willBeActive = nextNode != null && Matches(nextNode);
+
+            if (willBeActive)
+            {
+                ApplyActiveState(nextNode, context);
+            }
+            else
+            {
+                ApplyInactiveState(context);
+            }
+        }
+
+        protected virtual void ApplyActiveState(UIRouteNode nextNode, UIRouteChangeContext context)
+        {
+            LayerActivated?.Invoke(nextNode, context);
+        }
+
+        protected virtual void ApplyInactiveState(UIRouteChangeContext context)
+        {
+            LayerDeactivated?.Invoke(context);
+        }
+
+        private bool Matches(UIRouteNode node)
+        {
+            if (node == null) return false;
+
+            switch (activationFilter)
+            {
+                case NodeActivationFilter.MatchExactId:
+                    return !string.IsNullOrEmpty(nodeIdOrPrefix) && string.Equals(node.Id, nodeIdOrPrefix, StringComparison.Ordinal);
+                case NodeActivationFilter.MatchPrefix:
+                    return !string.IsNullOrEmpty(nodeIdOrPrefix) && node.Id != null && node.Id.StartsWith(nodeIdOrPrefix, StringComparison.Ordinal);
+                default:
+                    return true;
+            }
+        }
+    }
+}

--- a/ITC/Assets/Scripts/UIRouter/UIRouteChangeContext.cs
+++ b/ITC/Assets/Scripts/UIRouter/UIRouteChangeContext.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+namespace ITC.UIRouter
+{
+    /// <summary>
+    /// Provides context information about an upcoming route change.
+    /// </summary>
+    public sealed class UIRouteChangeContext
+    {
+        private readonly IReadOnlyList<UIRouteNode> _nextPath;
+
+        public UIRouteChangeContext(IReadOnlyList<UIRouteNode> nextPath)
+        {
+            _nextPath = nextPath ?? Array.Empty<UIRouteNode>();
+        }
+
+        public UIRouteNode NextNode(int level)
+        {
+            if (level < 0 || level >= _nextPath.Count)
+            {
+                return null;
+            }
+
+            return _nextPath[level];
+        }
+    }
+}

--- a/ITC/Assets/Scripts/UIRouter/UIRouteNode.cs
+++ b/ITC/Assets/Scripts/UIRouter/UIRouteNode.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace ITC.UIRouter
+{
+    /// <summary>
+    /// Represents a single node within a UI route hierarchy.
+    /// </summary>
+    public sealed class UIRouteNode
+    {
+        public UIRouteNode(string id, IReadOnlyList<UIRouteNode> children = null)
+        {
+            Id = id ?? string.Empty;
+            if (children != null)
+            {
+                _children.AddRange(children);
+            }
+        }
+
+        public string Id { get; }
+
+        private readonly List<UIRouteNode> _children = new List<UIRouteNode>();
+
+        public IReadOnlyList<UIRouteNode> Children => _children;
+
+        public void AddChild(UIRouteNode node)
+        {
+            if (node == null) throw new ArgumentNullException(nameof(node));
+            _children.Add(node);
+        }
+    }
+}

--- a/ITC/Assets/UIRouterSetup.md
+++ b/ITC/Assets/UIRouterSetup.md
@@ -1,0 +1,15 @@
+# UIRouter 节点过滤
+
+在同一层存在多个监督（Layer Manager）时，可以通过节点过滤来限制哪些面板会在层切换时被激活：
+
+- **Settings 面板**：`activationFilter = MatchExactId`，`nodeIdOrPrefix = "Settings"`
+- **Save 面板**：`activationFilter = MatchExactId`，`nodeIdOrPrefix = "Save"`
+
+若监督负责一组子页，可改用前缀匹配，例如：
+
+- `activationFilter = MatchPrefix`
+- `nodeIdOrPrefix = "Settings/"`
+
+这样在执行 `UIRouter.GoTo("Pause/Settings/Audio", PrimaryMenu)` 时，只会激活匹配此前缀的监督。需要的 payload 可以在 `onLayerEntered` 内读取，深链路径解析已经由 `UIRoute.BuildPath()` 处理。
+
+路由切换前，Router 会统一执行 `Kill(false)` 以清理残留的过渡动画，因此无需额外处理。


### PR DESCRIPTION
## Summary
- add a node activation filter enum and configuration on the UI hierarchy layer manager
- introduce simple route node/context helpers used during activation checks
- document how to configure node filtering for layered supervisors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eca161a5c48329a7cfbf70718e79f0