### PR TITLE
Add animation-first Director UI system

### DIFF
--- a/ITC/Assets/Scripts/UIAnimationDirectorSystem.meta
+++ b/ITC/Assets/Scripts/UIAnimationDirectorSystem.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e48df80f15a43a2a3ec43da65c49c7d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/UIAnimationDirectorSystem/Editor.meta
+++ b/ITC/Assets/Scripts/UIAnimationDirectorSystem/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 56d5891d52ce4f81b24a5ac153901ecb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/UIAnimationDirectorSystem/Editor/UIDirectorEditor.cs
+++ b/ITC/Assets/Scripts/UIAnimationDirectorSystem/Editor/UIDirectorEditor.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace DirectorUI.Editor
+{
+    [CustomEditor(typeof(UIDirector))]
+    public class UIDirectorEditor : UnityEditor.Editor
+    {
+        private SerializedProperty transitionTicketsProperty;
+        private SerializedProperty startingViewIdProperty;
+        private SerializedProperty tweenPlayerProperty;
+
+        private void OnEnable()
+        {
+            transitionTicketsProperty = serializedObject.FindProperty("transitionTickets");
+            startingViewIdProperty = serializedObject.FindProperty("startingViewId");
+            tweenPlayerProperty = serializedObject.FindProperty("tweenPlayer");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            EditorGUILayout.PropertyField(tweenPlayerProperty);
+            EditorGUILayout.PropertyField(transitionTicketsProperty, includeChildren: true);
+
+            DrawStartingViewSelector();
+
+            serializedObject.ApplyModifiedProperties();
+
+            DrawRuntimePreview();
+        }
+
+        private void DrawStartingViewSelector()
+        {
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Starting View", EditorStyles.boldLabel);
+
+            var ids = CollectViewIds();
+            if (ids.Count == 0)
+            {
+                EditorGUILayout.HelpBox("場景中尚未找到任何 UIView。可在 Play 模式或場景中放置後重試。", MessageType.Info);
+                EditorGUILayout.PropertyField(startingViewIdProperty);
+                return;
+            }
+
+            var display = new string[ids.Count];
+            for (int i = 0; i < ids.Count; i++)
+            {
+                display[i] = string.IsNullOrEmpty(ids[i]) ? "<None>" : ids[i];
+            }
+
+            var currentValue = startingViewIdProperty.stringValue;
+            var currentIndex = Mathf.Max(0, ids.IndexOf(currentValue));
+            var newIndex = EditorGUILayout.Popup(new GUIContent("Starting View Id"), currentIndex, display);
+            startingViewIdProperty.stringValue = ids[newIndex];
+        }
+
+        private List<string> CollectViewIds()
+        {
+            var result = new List<string> { string.Empty };
+            foreach (var view in UnityEngine.Object.FindObjectsOfType<UIView>(true))
+            {
+                if (view == null) continue;
+                if (string.IsNullOrEmpty(view.ViewId)) continue;
+                if (!result.Contains(view.ViewId))
+                {
+                    result.Add(view.ViewId);
+                }
+            }
+            return result;
+        }
+
+        private void DrawRuntimePreview()
+        {
+            if (!Application.isPlaying) return;
+
+            var director = (UIDirector)target;
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Runtime State", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField("Current View", director.CurrentView ? director.CurrentView.ViewId : "None");
+            EditorGUILayout.LabelField("Is Transitioning", director.IsTransitioning ? "True" : "False");
+        }
+    }
+}

--- a/ITC/Assets/Scripts/UIAnimationDirectorSystem/Editor/UIDirectorEditor.cs.meta
+++ b/ITC/Assets/Scripts/UIAnimationDirectorSystem/Editor/UIDirectorEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 18feeb60a4f842928b1fe04d80edbbcf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime.meta
+++ b/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9e36043f83984e5e8ee411c9c9f57f4e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UIDirector.cs
+++ b/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UIDirector.cs
@@ -1,0 +1,470 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DirectorUI
+{
+    /// <summary>
+    /// 全局導演，負責視圖註冊與過渡調度。
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(UITweenPlayer))]
+    public class UIDirector : MonoBehaviour
+    {
+        public static UIDirector Instance { get; private set; }
+        public static bool HasInstance => Instance != null;
+
+        private static readonly List<UIView> PendingViews = new();
+
+        [Tooltip("項目中所有的過渡票據 ScriptableObjects")]
+        [SerializeField] private List<UITransitionTicket> transitionTickets = new();
+
+        [Tooltip("指定初始顯示的視圖ID")]
+        [SerializeField] private string startingViewId = string.Empty;
+
+        [Tooltip("用於播放動畫預設的播放器")]
+        [SerializeField] private UITweenPlayer tweenPlayer;
+
+        private readonly Dictionary<string, UITransitionTicket> ticketLibrary = new();
+        private readonly Dictionary<string, UIView> viewRegistry = new();
+        private readonly Stack<UIView> viewStack = new();
+
+        public UIView CurrentView { get; private set; }
+        public bool IsTransitioning { get; private set; }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Debug.LogWarning("[UIDirector] Duplicate instance detected, destroying the newest one.", this);
+                Destroy(this);
+                return;
+            }
+
+            Instance = this;
+            if (tweenPlayer == null)
+            {
+                tweenPlayer = GetComponent<UITweenPlayer>();
+            }
+
+            BuildTicketLibrary();
+
+            foreach (var view in PendingViews)
+            {
+                RegisterView(view);
+            }
+            PendingViews.Clear();
+        }
+
+        private void Start()
+        {
+            if (!string.IsNullOrEmpty(startingViewId) && viewRegistry.TryGetValue(startingViewId, out var startView))
+            {
+                ForceShowView(startView);
+            }
+            else if (viewStack.Count == 0 && viewRegistry.Count > 0)
+            {
+                foreach (var view in viewRegistry.Values)
+                {
+                    ForceHideView(view);
+                }
+            }
+        }
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            if (tweenPlayer == null)
+            {
+                tweenPlayer = GetComponent<UITweenPlayer>();
+            }
+
+            if (!Application.isPlaying)
+            {
+                BuildTicketLibrary();
+            }
+        }
+#endif
+
+        public static void RegisterViewWhenReady(UIView view)
+        {
+            if (view == null) return;
+            if (HasInstance)
+            {
+                Instance.RegisterView(view);
+            }
+            else if (!PendingViews.Contains(view))
+            {
+                PendingViews.Add(view);
+            }
+        }
+
+        public static string BuildTicketKey(string fromId, string toId)
+        {
+            return $"{fromId ?? string.Empty}_{toId ?? string.Empty}";
+        }
+
+        public void RegisterView(UIView view)
+        {
+            if (view == null) return;
+            if (string.IsNullOrEmpty(view.ViewId))
+            {
+                Debug.LogWarning("[UIDirector] Attempted to register a view without viewId.", view);
+                return;
+            }
+
+            if (viewRegistry.TryGetValue(view.ViewId, out var existing) && existing != view)
+            {
+                Debug.LogWarning($"[UIDirector] Duplicate viewId detected: {view.ViewId}", view);
+                viewRegistry[view.ViewId] = view;
+            }
+            else
+            {
+                viewRegistry[view.ViewId] = view;
+            }
+        }
+
+        public void UnregisterView(UIView view)
+        {
+            if (view == null) return;
+            if (viewRegistry.TryGetValue(view.ViewId, out var existing) && existing == view)
+            {
+                viewRegistry.Remove(view.ViewId);
+            }
+
+            var remaining = new Stack<UIView>(viewStack.Count);
+            foreach (var item in viewStack)
+            {
+                if (item != view)
+                {
+                    remaining.Push(item);
+                }
+            }
+            viewStack.Clear();
+            foreach (var item in remaining)
+            {
+                viewStack.Push(item);
+            }
+
+            if (CurrentView == view)
+            {
+                CurrentView = null;
+            }
+        }
+
+        private void BuildTicketLibrary()
+        {
+            ticketLibrary.Clear();
+            foreach (var ticket in transitionTickets)
+            {
+                if (ticket == null) continue;
+                if (string.IsNullOrEmpty(ticket.fromViewId) || string.IsNullOrEmpty(ticket.toViewId))
+                {
+                    Debug.LogWarning($"[UIDirector] Ticket '{ticket.name}' has empty view id.");
+                    continue;
+                }
+
+                var key = ticket.TicketKey;
+                if (ticketLibrary.ContainsKey(key))
+                {
+                    Debug.LogWarning($"[UIDirector] Duplicate transition ticket detected for {key}.");
+                    continue;
+                }
+
+                ticketLibrary.Add(key, ticket);
+            }
+        }
+
+        public void ExecuteTransition(string toViewId)
+        {
+            if (IsTransitioning)
+            {
+                Debug.LogWarning("[UIDirector] Transition is already running.");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(toViewId))
+            {
+                Debug.LogWarning("[UIDirector] ExecuteTransition called with empty toViewId.");
+                return;
+            }
+
+            if (!viewRegistry.TryGetValue(toViewId, out var targetView))
+            {
+                Debug.LogWarning($"[UIDirector] Target view '{toViewId}' not registered.");
+                return;
+            }
+
+            if (CurrentView != null && CurrentView == targetView)
+            {
+                return;
+            }
+
+            UITransitionTicket ticket = null;
+            if (CurrentView != null)
+            {
+                var key = BuildTicketKey(CurrentView.ViewId, toViewId);
+                ticketLibrary.TryGetValue(key, out ticket);
+            }
+
+            StartCoroutine(PerformTransition(CurrentView, targetView, ticket, true));
+        }
+
+        public void GoBack()
+        {
+            if (IsTransitioning)
+            {
+                return;
+            }
+
+            if (viewStack.Count <= 1)
+            {
+                Debug.LogWarning("[UIDirector] No previous view in stack.");
+                return;
+            }
+
+            var current = viewStack.Pop();
+            var previous = viewStack.Peek();
+
+            UITransitionTicket ticket = null;
+            var key = BuildTicketKey(current.ViewId, previous.ViewId);
+            ticketLibrary.TryGetValue(key, out ticket);
+
+            StartCoroutine(PerformTransition(current, previous, ticket, false));
+        }
+
+        private IEnumerator PerformTransition(UIView fromView, UIView toView, UITransitionTicket ticket, bool pushToStack)
+        {
+            IsTransitioning = true;
+
+            if (toView != null)
+            {
+                toView.PrepareForIntro();
+            }
+
+            var window = new TransitionWindow();
+
+            if (ticket != null)
+            {
+                window.Extend(PlayStuntDoubleTransitions(fromView, toView, ticket));
+                window.Extend(PlayAnimationCollection(fromView, ticket.outroAnimations));
+                window.Extend(PlayAnimationCollection(toView, ticket.introAnimations));
+            }
+
+            if (window.HasDuration)
+            {
+                yield return WaitForWindow(window);
+            }
+
+            if (fromView != null)
+            {
+                fromView.Hide();
+            }
+
+            if (toView != null)
+            {
+                toView.Show();
+            }
+
+            CurrentView = toView;
+
+            if (pushToStack && toView != null)
+            {
+                if (viewStack.Count == 0 || viewStack.Peek() != toView)
+                {
+                    viewStack.Push(toView);
+                }
+            }
+
+            IsTransitioning = false;
+        }
+
+        private TransitionWindow PlayAnimationCollection(UIView view, List<UITransitionTicket.AnimationStep> steps)
+        {
+            var window = new TransitionWindow();
+            if (view == null || steps == null || steps.Count == 0) return window;
+
+            foreach (var step in steps)
+            {
+                if (step == null || step.animationPreset == null) continue;
+                var element = view.GetElement(step.elementId);
+                if (element == null)
+                {
+                    Debug.LogWarning($"[UIDirector] Element '{step.elementId}' not found in view '{view.ViewId}'.");
+                    continue;
+                }
+
+                StartCoroutine(PlayPresetWithDelay(element.gameObject, step.animationPreset, step.delay));
+
+                var duration = Mathf.Max(0f, step.delay) + EstimatePresetDuration(step.animationPreset);
+                if (step.animationPreset.unscaledTime)
+                {
+                    window.unscaled = Mathf.Max(window.unscaled, duration);
+                }
+                else
+                {
+                    window.scaled = Mathf.Max(window.scaled, duration);
+                }
+            }
+
+            return window;
+        }
+
+        private TransitionWindow PlayStuntDoubleTransitions(UIView fromView, UIView toView, UITransitionTicket ticket)
+        {
+            var window = new TransitionWindow();
+            if (fromView == null || toView == null || ticket.stuntDoubleTransitions == null || ticket.stuntDoubleTransitions.Count == 0)
+            {
+                return window;
+            }
+
+            foreach (var step in ticket.stuntDoubleTransitions)
+            {
+                if (step == null || step.flyingAnimationPreset == null) continue;
+                var original = fromView.GetElement(step.elementId);
+                var stunt = toView.GetElement(step.elementId);
+                if (original == null || stunt == null)
+                {
+                    Debug.LogWarning($"[UIDirector] Stunt step '{step.elementId}' missing element in views.");
+                    continue;
+                }
+
+                SetElementAlpha(stunt.gameObject, 0f);
+
+                StartCoroutine(PlayPresetWithDelay(original.gameObject, step.flyingAnimationPreset, 0f, () =>
+                {
+                    SetElementAlpha(original.gameObject, 0f);
+                    SetElementAlpha(stunt.gameObject, 1f);
+                }));
+
+                var duration = EstimatePresetDuration(step.flyingAnimationPreset);
+                if (step.flyingAnimationPreset.unscaledTime)
+                {
+                    window.unscaled = Mathf.Max(window.unscaled, duration);
+                }
+                else
+                {
+                    window.scaled = Mathf.Max(window.scaled, duration);
+                }
+            }
+
+            return window;
+        }
+
+        private IEnumerator PlayPresetWithDelay(GameObject target, UITweenPreset preset, float delay, System.Action onComplete = null)
+        {
+            if (preset == null || target == null)
+            {
+                yield break;
+            }
+
+            if (delay > 0f)
+            {
+                if (preset.unscaledTime)
+                {
+                    yield return new WaitForSecondsRealtime(delay);
+                }
+                else
+                {
+                    yield return new WaitForSeconds(delay);
+                }
+            }
+
+            if (tweenPlayer == null)
+            {
+                Debug.LogWarning("[UIDirector] Tween player not configured.");
+                onComplete?.Invoke();
+                yield break;
+            }
+
+            tweenPlayer.Play(target, preset, onComplete);
+        }
+
+        private void ForceShowView(UIView view)
+        {
+            foreach (var v in viewRegistry.Values)
+            {
+                if (v != view)
+                {
+                    ForceHideView(v);
+                }
+            }
+
+            view.Show();
+            if (!viewStack.Contains(view))
+            {
+                viewStack.Push(view);
+            }
+            CurrentView = view;
+        }
+
+        private void ForceHideView(UIView view)
+        {
+            view.Hide();
+        }
+
+        private void SetElementAlpha(GameObject target, float alpha)
+        {
+            if (target == null) return;
+            if (target.TryGetComponent<CanvasGroup>(out var cg))
+            {
+                cg.alpha = alpha;
+            }
+            else
+            {
+                var graphics = target.GetComponentsInChildren<UnityEngine.UI.Graphic>(true);
+                foreach (var graphic in graphics)
+                {
+                    var color = graphic.color;
+                    color.a = alpha;
+                    graphic.color = color;
+                }
+            }
+        }
+
+        private static IEnumerator WaitForWindow(TransitionWindow window)
+        {
+            if (window.scaled > 0f)
+            {
+                yield return new WaitForSeconds(window.scaled);
+            }
+
+            if (window.unscaled > 0f)
+            {
+                float remaining = Mathf.Max(0f, window.unscaled - Mathf.Max(window.scaled, 0f));
+
+                if (window.scaled <= 0f)
+                {
+                    yield return new WaitForSecondsRealtime(window.unscaled);
+                }
+                else if (remaining > 0f)
+                {
+                    yield return new WaitForSecondsRealtime(remaining);
+                }
+            }
+        }
+
+        private static float EstimatePresetDuration(UITweenPreset preset)
+        {
+            if (preset == null) return 0f;
+            var duration = Mathf.Max(0f, preset.duration);
+            var loops = Mathf.Max(0, preset.loops);
+            var total = duration * (loops + 1);
+            return Mathf.Max(0f, preset.delay) + total;
+        }
+
+        private struct TransitionWindow
+        {
+            public float scaled;
+            public float unscaled;
+
+            public void Extend(TransitionWindow other)
+            {
+                scaled = Mathf.Max(scaled, other.scaled);
+                unscaled = Mathf.Max(unscaled, other.unscaled);
+            }
+
+            public bool HasDuration => scaled > 0f || unscaled > 0f;
+        }
+    }
+}

--- a/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UIDirector.cs.meta
+++ b/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UIDirector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 33d7df614320467d9f77a441f52c5446
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UITransitionElement.cs
+++ b/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UITransitionElement.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+namespace DirectorUI
+{
+    /// <summary>
+    /// Identifies a transitionable UI element inside a <see cref="UIView"/>.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class UITransitionElement : MonoBehaviour
+    {
+        [Tooltip("此元素在其所屬 UIView 內的唯一標識符")]
+        [SerializeField] private string elementId = string.Empty;
+
+        /// <summary>
+        /// Unique identifier for this element inside its parent view.
+        /// </summary>
+        public string ElementId => elementId;
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            if (string.IsNullOrWhiteSpace(elementId))
+            {
+                elementId = gameObject.name;
+            }
+        }
+#endif
+    }
+}

--- a/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UITransitionElement.cs.meta
+++ b/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UITransitionElement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4a046f720e04424b945723eeafc7af5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UITransitionTicket.cs
+++ b/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UITransitionTicket.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DirectorUI
+{
+    [CreateAssetMenu(fileName = "UITransitionTicket", menuName = "DirectorUI/Transition Ticket")]
+    public class UITransitionTicket : ScriptableObject
+    {
+        [Tooltip("過渡的起始視圖ID")]
+        public string fromViewId;
+        [Tooltip("過渡的目標視圖ID")]
+        public string toViewId;
+
+        [Header("動畫編排")]
+        public List<AnimationStep> outroAnimations = new();
+        public List<AnimationStep> introAnimations = new();
+        public List<StuntDoubleStep> stuntDoubleTransitions = new();
+
+        public string TicketKey => UIDirector.BuildTicketKey(fromViewId, toViewId);
+
+        [System.Serializable]
+        public class AnimationStep
+        {
+            [Tooltip("目標元素的ID")]
+            public string elementId;
+            [Tooltip("要播放的動畫預設")]
+            public UITweenPreset animationPreset;
+            [Tooltip("延遲播放時間（秒）")]
+            public float delay = 0f;
+        }
+
+        [System.Serializable]
+        public class StuntDoubleStep
+        {
+            [Tooltip("原身和替身共同的元素ID")]
+            public string elementId;
+            [Tooltip("原身飛向替身位置的動畫預設")]
+            public UITweenPreset flyingAnimationPreset;
+        }
+    }
+}

--- a/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UITransitionTicket.cs.meta
+++ b/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UITransitionTicket.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dbb47832751d4ffeb065137bc7a6cf8c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UITweenPlayer.cs
+++ b/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UITweenPlayer.cs
@@ -1,0 +1,48 @@
+using System;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace DirectorUI
+{
+    /// <summary>
+    /// Lightweight player that bridges <see cref="UITransitionTicket"/> data to the existing goal-driven tween system.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class UITweenPlayer : MonoBehaviour
+    {
+        /// <summary>
+        /// 播放一個動畫預設，並在動畫完成時調用 onComplete 回調。
+        /// </summary>
+        public void Play(GameObject target, UITweenPreset preset, Action onComplete = null)
+        {
+            if (target == null || preset == null)
+            {
+                onComplete?.Invoke();
+                return;
+            }
+
+            if (!target.TryGetComponent(out global::UITweenPlayer player))
+            {
+                Debug.LogWarning($"[DirectorUI] GameObject '{target.name}' 缺少 UITweenPlayer 組件。", target);
+                onComplete?.Invoke();
+                return;
+            }
+
+            if (onComplete == null)
+            {
+                player.Play(preset);
+                return;
+            }
+
+            UnityAction handler = null;
+            handler = () =>
+            {
+                player.onComplete.RemoveListener(handler);
+                onComplete.Invoke();
+            };
+
+            player.onComplete.AddListener(handler);
+            player.Play(preset);
+        }
+    }
+}

--- a/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UITweenPlayer.cs.meta
+++ b/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UITweenPlayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3cc115c3905c4f639ac79c733ab4c4e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UIView.cs
+++ b/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UIView.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DirectorUI
+{
+    [RequireComponent(typeof(CanvasGroup))]
+    [DisallowMultipleComponent]
+    public class UIView : MonoBehaviour
+    {
+        [Tooltip("此視圖的唯一標識符")]
+        [SerializeField] private string viewId = string.Empty;
+
+        public string ViewId => viewId;
+        public CanvasGroup CanvasGroup { get; private set; }
+
+        private readonly Dictionary<string, UITransitionElement> elementRegistry = new();
+
+        private void Awake()
+        {
+            CanvasGroup = GetComponent<CanvasGroup>();
+            RebuildElementRegistry();
+            UIDirector.RegisterViewWhenReady(this);
+        }
+
+        private void OnDestroy()
+        {
+            if (UIDirector.HasInstance)
+            {
+                UIDirector.Instance.UnregisterView(this);
+            }
+        }
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            CanvasGroup = GetComponent<CanvasGroup>();
+            RebuildElementRegistry();
+        }
+#endif
+
+        public void RebuildElementRegistry()
+        {
+            elementRegistry.Clear();
+            var elements = GetComponentsInChildren<UITransitionElement>(true);
+            foreach (var element in elements)
+            {
+                if (element == null) continue;
+                var id = element.ElementId;
+                if (string.IsNullOrEmpty(id)) continue;
+                if (!elementRegistry.ContainsKey(id))
+                {
+                    elementRegistry.Add(id, element);
+                }
+                else
+                {
+                    Debug.LogWarning($"[UIView] Duplicate elementId '{id}' detected under view '{viewId}'.", element);
+                }
+            }
+        }
+
+        public UITransitionElement GetElement(string elementId)
+        {
+            if (string.IsNullOrEmpty(elementId)) return null;
+            elementRegistry.TryGetValue(elementId, out var element);
+            return element;
+        }
+
+        public void PrepareForIntro()
+        {
+            gameObject.SetActive(true);
+            CanvasGroup.alpha = 0f;
+            CanvasGroup.interactable = false;
+            CanvasGroup.blocksRaycasts = false;
+        }
+
+        public void Show()
+        {
+            gameObject.SetActive(true);
+            CanvasGroup.alpha = 1f;
+            CanvasGroup.interactable = true;
+            CanvasGroup.blocksRaycasts = true;
+        }
+
+        public void Hide()
+        {
+            CanvasGroup.alpha = 0f;
+            CanvasGroup.interactable = false;
+            CanvasGroup.blocksRaycasts = false;
+            gameObject.SetActive(false);
+        }
+    }
+}

--- a/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UIView.cs.meta
+++ b/ITC/Assets/Scripts/UIAnimationDirectorSystem/Runtime/UIView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 60b355a67c0c4ba2931436515a0650cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add the DirectorUI runtime components for orchestrating view transitions and history
- define the UITransitionTicket ScriptableObject data model and tween player bridge
- create an inspector utility to simplify picking the initial view in the director

## Testing
- Not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ef023eb03c832998089924cc64de53