### PR TITLE
Improve UITween debug diagnostics

### DIFF
--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenDebugTester.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenDebugTester.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 using DG.Tweening;
 using UnityEngine;
@@ -29,6 +30,8 @@ public class UITweenDebugTester : MonoBehaviour
 
     PlaybackDebugSnapshot _pendingSnapshot;
     float _playStartTime;
+    float _expectedFinishTime;
+    bool _overdueLogged;
     bool _awaitingCompletion;
 
     void Reset()
@@ -139,6 +142,17 @@ public class UITweenDebugTester : MonoBehaviour
 
         ComputeTargets(ref snapshot);
 
+        if (sequence != null)
+        {
+            float delay = TweenExtensions.Delay(sequence);
+            float duration = (float)TweenExtensions.Duration(sequence, includeLoops: true);
+            snapshot.expectedDuration = delay + duration;
+        }
+        else
+        {
+            snapshot.expectedDuration = ComputeExpectedDurationFallback(snapshot);
+        }
+
         _pendingSnapshot = snapshot;
         _awaitingCompletion = true;
 
@@ -154,6 +168,15 @@ public class UITweenDebugTester : MonoBehaviour
             return;
 
         _playStartTime = _pendingSnapshot.unscaledTime ? Time.unscaledTime : Time.time;
+        _overdueLogged = false;
+        if (!float.IsInfinity(_pendingSnapshot.expectedDuration))
+        {
+            _expectedFinishTime = _playStartTime + _pendingSnapshot.expectedDuration;
+        }
+        else
+        {
+            _expectedFinishTime = float.PositiveInfinity;
+        }
 
         var sb = new StringBuilder();
         sb.AppendLine($"[UITweenDebugTester] ▶ Play '{_pendingSnapshot.preset.presetName}' {( _pendingSnapshot.reversed ? "(reversed)" : string.Empty)}");
@@ -198,6 +221,16 @@ public class UITweenDebugTester : MonoBehaviour
         if (_pendingSnapshot.targetColor.HasValue)
             sb.AppendLine($"    Color      : {_pendingSnapshot.targetColor.Value}");
 
+        string originSummary;
+        var callStack = CaptureInvocationTrace(out originSummary);
+        if (!string.IsNullOrEmpty(originSummary))
+            sb.AppendLine($"  Triggered By: {originSummary}");
+        if (!string.IsNullOrEmpty(callStack))
+        {
+            sb.AppendLine("  Call Stack:");
+            sb.Append(callStack);
+        }
+
         if (_pendingSnapshot.usesBezier)
         {
             sb.AppendLine("  Path (Quadratic Bezier):");
@@ -219,8 +252,22 @@ public class UITweenDebugTester : MonoBehaviour
         _awaitingCompletion = false;
         float finishedAt = _pendingSnapshot.unscaledTime ? Time.unscaledTime : Time.time;
         float elapsed = finishedAt - _playStartTime;
+        var snapshot = _pendingSnapshot;
 
-        Debug.Log($"[UITweenDebugTester] ✔ Complete '{_pendingSnapshot.preset.presetName}' in {elapsed:0.###}s (configured {_pendingSnapshot.duration:0.###}s).", this);
+        var sb = new StringBuilder();
+        sb.AppendLine($"[UITweenDebugTester] ✔ Complete '{snapshot.preset.presetName}' in {elapsed:0.###}s (configured {snapshot.duration:0.###}s).");
+
+        if (!float.IsInfinity(snapshot.expectedDuration))
+        {
+            float expected = snapshot.expectedDuration;
+            float delta = Mathf.Abs(elapsed - expected);
+            sb.AppendLine($"  Expected total duration: {expected:0.###}s (Δ {delta:0.###}s)");
+        }
+
+        var currentState = CaptureCurrentState();
+        AppendStateComparison(ref sb, snapshot, currentState);
+
+        Debug.Log(sb.ToString(), this);
     }
 
     void HandleSequenceKilled(Sequence sequence)
@@ -230,6 +277,25 @@ public class UITweenDebugTester : MonoBehaviour
 
         _awaitingCompletion = false;
         Debug.LogWarning($"[UITweenDebugTester] ✖ Tween '{_pendingSnapshot.preset.presetName}' was interrupted before completion.", this);
+    }
+
+    void Update()
+    {
+        if (!debugEnabled || !_awaitingCompletion || _pendingSnapshot.preset == null)
+            return;
+
+        if (float.IsInfinity(_expectedFinishTime))
+            return;
+
+        float now = _pendingSnapshot.unscaledTime ? Time.unscaledTime : Time.time;
+        const float tolerance = 0.1f;
+        if (!_overdueLogged && now > _expectedFinishTime + tolerance)
+        {
+            _overdueLogged = true;
+            bool sequencePlaying = _pendingSnapshot.sequence != null && TweenExtensions.IsPlaying(_pendingSnapshot.sequence);
+            string status = sequencePlaying ? "Sequence still reports playing" : "Sequence is inactive";
+            Debug.LogWarning($"[UITweenDebugTester] ⚠ Tween '{_pendingSnapshot.preset.presetName}' exceeded expected duration ({_pendingSnapshot.expectedDuration:0.###}s). {status}.", this);
+        }
     }
 
     void ComputeTargets(ref PlaybackDebugSnapshot snapshot)
@@ -346,6 +412,142 @@ public class UITweenDebugTester : MonoBehaviour
         return sb.ToString();
     }
 
+    string CaptureInvocationTrace(out string originSummary)
+    {
+        originSummary = string.Empty;
+        var trace = new StackTrace(1, true);
+        var sb = new StringBuilder();
+        bool originAssigned = false;
+        for (int i = 0; i < trace.FrameCount; i++)
+        {
+            var frame = trace.GetFrame(i);
+            var method = frame.GetMethod();
+            if (method == null)
+                continue;
+
+            var declaringType = method.DeclaringType;
+            string typeName = declaringType != null ? declaringType.FullName : "<global>";
+            if (typeName != null && (typeName.Contains(nameof(UITweenDebugTester)) || typeName.StartsWith("DG.Tweening") || typeName.StartsWith("System.")))
+                continue;
+
+            string formatted = FormatFrame(typeName, method.Name, frame);
+            if (!originAssigned)
+            {
+                originAssigned = true;
+                originSummary = formatted.Trim();
+            }
+            sb.Append("    ");
+            sb.AppendLine(formatted);
+        }
+
+        return sb.ToString();
+    }
+
+    static string FormatFrame(string typeName, string methodName, StackFrame frame)
+    {
+        var sb = new StringBuilder();
+        sb.Append(typeName);
+        sb.Append('.');
+        sb.Append(methodName);
+        sb.Append(" (at ");
+        string fileName = frame.GetFileName();
+        if (!string.IsNullOrEmpty(fileName))
+        {
+            sb.Append(fileName);
+            sb.Append(':');
+            sb.Append(frame.GetFileLineNumber());
+        }
+        else
+        {
+            sb.Append("<unknown>");
+        }
+        sb.Append(')');
+        return sb.ToString();
+    }
+
+    PlaybackStateSnapshot CaptureCurrentState()
+    {
+        var state = new PlaybackStateSnapshot();
+
+        if (_rt != null)
+        {
+            state.position = _rt.anchoredPosition;
+            state.size = _rt.sizeDelta;
+            state.eulerZ = _rt.eulerAngles.z;
+            state.pivot = _rt.pivot;
+        }
+
+        if (_cg != null)
+        {
+            state.alpha = _cg.alpha;
+        }
+        else if (_gfx != null)
+        {
+            state.alpha = _gfx.color.a;
+            state.color = _gfx.color;
+        }
+
+        return state;
+    }
+
+    void AppendStateComparison(ref StringBuilder sb, in PlaybackDebugSnapshot expectedSnapshot, in PlaybackStateSnapshot actual)
+    {
+        sb.AppendLine("  Final State:");
+        sb.AppendLine($"    AnchoredPos: {actual.position}");
+        sb.AppendLine($"    SizeDelta  : {actual.size}");
+        sb.AppendLine($"    EulerZ     : {actual.eulerZ:0.###}");
+        sb.AppendLine($"    Pivot      : {actual.pivot}");
+        if (actual.alpha.HasValue)
+            sb.AppendLine($"    Alpha      : {actual.alpha.Value:0.###}");
+        if (actual.color.HasValue)
+            sb.AppendLine($"    Color      : {actual.color.Value}");
+
+        sb.AppendLine("  Comparison vs Target:");
+        AppendComparisonLine(ref sb, "AnchoredPos", actual.position, expectedSnapshot.targetAnchoredPosition, 0.5f);
+        AppendComparisonLine(ref sb, "SizeDelta", actual.size, expectedSnapshot.targetSize, 0.5f);
+        AppendComparisonLine(ref sb, "EulerZ", actual.eulerZ, expectedSnapshot.targetEulerZ, 0.5f);
+
+        if (expectedSnapshot.targetPivot.HasValue)
+            AppendComparisonLine(ref sb, "Pivot", actual.pivot, expectedSnapshot.targetPivot.Value, 0.001f);
+
+        if (expectedSnapshot.targetAlpha.HasValue && actual.alpha.HasValue)
+            AppendComparisonLine(ref sb, "Alpha", actual.alpha.Value, expectedSnapshot.targetAlpha.Value, 0.01f);
+
+        if (expectedSnapshot.targetColor.HasValue && actual.color.HasValue)
+        {
+            var expectedColor = expectedSnapshot.targetColor.Value;
+            var actualColor = actual.color.Value;
+            float delta = Mathf.Max(Mathf.Abs(actualColor.r - expectedColor.r), Mathf.Abs(actualColor.g - expectedColor.g), Mathf.Abs(actualColor.b - expectedColor.b), Mathf.Abs(actualColor.a - expectedColor.a));
+            sb.AppendLine($"    Color Δmax: {delta:0.###} (target {expectedColor})");
+        }
+    }
+
+    static void AppendComparisonLine(ref StringBuilder sb, string label, Vector2 actual, Vector2 expected, float tolerance)
+    {
+        float delta = Vector2.Distance(actual, expected);
+        sb.AppendLine($"    {label} Δ: {delta:0.###} (target {expected})");
+        if (delta > tolerance)
+            sb.AppendLine($"      ⚠ {label} difference exceeds tolerance {tolerance:0.###}");
+    }
+
+    static void AppendComparisonLine(ref StringBuilder sb, string label, float actual, float expected, float tolerance)
+    {
+        float delta = Mathf.Abs(actual - expected);
+        sb.AppendLine($"    {label} Δ: {delta:0.###} (target {expected:0.###})");
+        if (delta > tolerance)
+            sb.AppendLine($"      ⚠ {label} difference exceeds tolerance {tolerance:0.###}");
+    }
+
+    static float ComputeExpectedDurationFallback(in PlaybackDebugSnapshot snapshot)
+    {
+        if (snapshot.loops < 0)
+            return float.PositiveInfinity;
+
+        float cycles = Mathf.Max(1, snapshot.loops + 1);
+        float total = snapshot.delay + snapshot.duration * cycles;
+        return total;
+    }
+
     struct PlaybackDebugSnapshot
     {
         public UITweenPreset preset;
@@ -386,5 +588,16 @@ public class UITweenDebugTester : MonoBehaviour
         public bool useCustomCurve;
         public AnimationCurve customCurve;
         public Ease ease;
+        public float expectedDuration;
+    }
+
+    struct PlaybackStateSnapshot
+    {
+        public Vector2 position;
+        public Vector2 size;
+        public float eulerZ;
+        public Vector2 pivot;
+        public float? alpha;
+        public Color? color;
     }
 }


### PR DESCRIPTION
## Summary
- add stack trace capture and invocation origin details when tweens play
- log expected durations alongside final state comparisons for completed animations
- monitor active sequences for overruns and interruptions to surface stuck playback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef892d8fe48329b3b1cee466223f8e