### PR TITLE
Add runtime UITween monitor instrumentation

### DIFF
--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenMonitorWindow.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenMonitorWindow.cs
@@ -1,0 +1,184 @@
+#if UNITY_EDITOR
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// Editor window for inspecting UITween monitor traffic during Play Mode.
+/// </summary>
+public class UITweenMonitorWindow : EditorWindow
+{
+    private readonly List<UITweenMonitor.UITweenMonitorEntry> _entries = new();
+    private readonly HashSet<long> _expanded = new();
+    private Vector2 _scroll;
+    private string _search = string.Empty;
+    private bool _showPending = true;
+    private bool _showPlaying = true;
+    private bool _showCompleted = true;
+    private bool _showInterrupted = true;
+
+    [MenuItem("Window/UI/UITween Monitor")]
+    public static void Open()
+    {
+        var window = GetWindow<UITweenMonitorWindow>("UITween Monitor");
+        window.Show();
+    }
+
+    private void OnEnable()
+    {
+        UITweenMonitor.Instance.Changed += Repaint;
+        EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+    }
+
+    private void OnDisable()
+    {
+        UITweenMonitor.Instance.Changed -= Repaint;
+        EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+    }
+
+    private void OnPlayModeStateChanged(PlayModeStateChange change)
+    {
+        if (change == PlayModeStateChange.EnteredEditMode)
+        {
+            UITweenMonitor.Instance.Clear();
+        }
+    }
+
+    private void OnGUI()
+    {
+        DrawToolbar();
+
+        var monitor = UITweenMonitor.Instance;
+        monitor.GetEntries(_entries);
+
+        if (!EditorApplication.isPlaying)
+        {
+            EditorGUILayout.HelpBox("Enter Play Mode to capture runtime UITween traffic.", MessageType.Info);
+        }
+
+        string searchLower = string.IsNullOrEmpty(_search) ? null : _search.ToLowerInvariant();
+        double now = EditorApplication.isPlaying ? Time.realtimeSinceStartup : 0d;
+
+        _scroll = EditorGUILayout.BeginScrollView(_scroll);
+        foreach (var entry in _entries)
+        {
+            if (!IsStatusVisible(entry.status)) continue;
+            if (!PassesSearch(entry, searchLower)) continue;
+            DrawEntry(entry, now);
+        }
+        EditorGUILayout.EndScrollView();
+    }
+
+    private void DrawToolbar()
+    {
+        EditorGUILayout.BeginHorizontal(EditorStyles.toolbar);
+        GUILayout.Label("Search", GUILayout.Width(50f));
+        _search = GUILayout.TextField(_search, EditorStyles.toolbarTextField, GUILayout.ExpandWidth(true));
+        if (GUILayout.Button("Clear", EditorStyles.toolbarButton, GUILayout.Width(60f)))
+        {
+            _search = string.Empty;
+        }
+        GUILayout.FlexibleSpace();
+        _showPending = GUILayout.Toggle(_showPending, "Pending", EditorStyles.toolbarButton);
+        _showPlaying = GUILayout.Toggle(_showPlaying, "Playing", EditorStyles.toolbarButton);
+        _showCompleted = GUILayout.Toggle(_showCompleted, "Completed", EditorStyles.toolbarButton);
+        _showInterrupted = GUILayout.Toggle(_showInterrupted, "Interrupted", EditorStyles.toolbarButton);
+        if (GUILayout.Button("Clear Buffer", EditorStyles.toolbarButton, GUILayout.Width(90f)))
+        {
+            UITweenMonitor.Instance.Clear();
+        }
+        EditorGUILayout.EndHorizontal();
+    }
+
+    private bool IsStatusVisible(UITweenMonitor.EntryStatus status)
+    {
+        return (status == UITweenMonitor.EntryStatus.Pending && _showPending)
+            || (status == UITweenMonitor.EntryStatus.Playing && _showPlaying)
+            || (status == UITweenMonitor.EntryStatus.Completed && _showCompleted)
+            || (status == UITweenMonitor.EntryStatus.Interrupted && _showInterrupted);
+    }
+
+    private bool PassesSearch(in UITweenMonitor.UITweenMonitorEntry entry, string searchLower)
+    {
+        if (string.IsNullOrEmpty(searchLower)) return true;
+        if (!string.IsNullOrEmpty(entry.presetName) && entry.presetName.ToLowerInvariant().Contains(searchLower)) return true;
+        if (!string.IsNullOrEmpty(entry.responderName) && entry.responderName.ToLowerInvariant().Contains(searchLower)) return true;
+        if (!string.IsNullOrEmpty(entry.responderPath) && entry.responderPath.ToLowerInvariant().Contains(searchLower)) return true;
+        if (!string.IsNullOrEmpty(entry.initiatorName) && entry.initiatorName.ToLowerInvariant().Contains(searchLower)) return true;
+        if (!string.IsNullOrEmpty(entry.initiatorDetails) && entry.initiatorDetails.ToLowerInvariant().Contains(searchLower)) return true;
+        if (!string.IsNullOrEmpty(entry.initiatorType) && entry.initiatorType.ToLowerInvariant().Contains(searchLower)) return true;
+        if (!string.IsNullOrEmpty(entry.initiatorMethod) && entry.initiatorMethod.ToLowerInvariant().Contains(searchLower)) return true;
+        return false;
+    }
+
+    private void DrawEntry(in UITweenMonitor.UITweenMonitorEntry entry, double now)
+    {
+        bool expanded = _expanded.Contains(entry.requestId);
+        string header = string.Format("#{0} · {1} · {2}{3}",
+            entry.requestId,
+            entry.status,
+            entry.presetName,
+            entry.reversed ? " (Reversed)" : string.Empty);
+
+        EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+        expanded = EditorGUILayout.Foldout(expanded, header, true);
+        if (expanded)
+        {
+            _expanded.Add(entry.requestId);
+            EditorGUI.indentLevel++;
+
+            double start = entry.startedAt > 0.0 ? entry.startedAt : entry.createdAt;
+            double end = entry.endedAt > 0.0 ? entry.endedAt : (EditorApplication.isPlaying ? now : start);
+            double duration = Mathf.Max(0f, (float)(end - start));
+            EditorGUILayout.LabelField("Duration", duration.ToString("0.000") + " s");
+            EditorGUILayout.LabelField("Frames", entry.startFrame + " → " + entry.endFrame);
+            EditorGUILayout.LabelField("Responder", entry.responderName + " · " + entry.responderPath);
+            EditorGUILayout.LabelField("Initiator", BuildInitiatorLine(entry));
+            if (!string.IsNullOrEmpty(entry.interruptionReason))
+            {
+                EditorGUILayout.LabelField("Reason", entry.interruptionReason);
+            }
+
+            EditorGUILayout.BeginHorizontal();
+            if (GUILayout.Button("Ping Player", EditorStyles.miniButtonLeft) && entry.responderObject != null)
+            {
+                EditorGUIUtility.PingObject(entry.responderObject);
+                Selection.activeObject = entry.responderObject;
+            }
+            if (GUILayout.Button("Ping Initiator", EditorStyles.miniButtonMid) && entry.initiatorObject != null)
+            {
+                EditorGUIUtility.PingObject(entry.initiatorObject);
+                Selection.activeObject = entry.initiatorObject;
+            }
+            if (GUILayout.Button("Copy Stack", EditorStyles.miniButtonRight) && !string.IsNullOrEmpty(entry.initiatorStack))
+            {
+                EditorGUIUtility.systemCopyBuffer = entry.initiatorStack;
+            }
+            EditorGUILayout.EndHorizontal();
+
+            if (!string.IsNullOrEmpty(entry.initiatorStack))
+            {
+                EditorGUILayout.LabelField("Stack Trace:");
+                EditorGUILayout.TextArea(entry.initiatorStack, GUILayout.MinHeight(60f));
+            }
+
+            EditorGUI.indentLevel--;
+        }
+        else
+        {
+            _expanded.Remove(entry.requestId);
+        }
+        EditorGUILayout.EndVertical();
+    }
+
+    private string BuildInitiatorLine(in UITweenMonitor.UITweenMonitorEntry entry)
+    {
+        var pieces = new List<string>(4);
+        if (!string.IsNullOrEmpty(entry.initiatorType)) pieces.Add(entry.initiatorType);
+        if (!string.IsNullOrEmpty(entry.initiatorName)) pieces.Add(entry.initiatorName);
+        if (!string.IsNullOrEmpty(entry.initiatorDetails)) pieces.Add(entry.initiatorDetails);
+        if (!string.IsNullOrEmpty(entry.initiatorMethod)) pieces.Add(entry.initiatorMethod);
+        return string.Join(" · ", pieces);
+    }
+}
+#endif

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenMonitorWindow.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenMonitorWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4fcfe9b1d8624d15b9b6213b5636e33b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenCallContext.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenCallContext.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using UnityEngine;
+
+/// <summary>
+/// Captures and propagates call-site information for UITween requests without changing existing APIs.
+/// </summary>
+public static class UITweenCallContext
+{
+    private static readonly AsyncLocal<ContextInfo?> _current = new();
+
+    /// <summary>
+    /// A snapshot of the call context used by the monitor.
+    /// </summary>
+    public readonly struct ContextInfo
+    {
+        public readonly string SourceType;
+        public readonly string SourceName;
+        public readonly string Details;
+        public readonly string Method;
+        public readonly string StackTrace;
+        public readonly UnityEngine.Object SourceObject;
+        public readonly int Depth;
+
+        public ContextInfo(string sourceType, string sourceName, string details, string method, string stackTrace, UnityEngine.Object sourceObject, int depth)
+        {
+            SourceType = sourceType;
+            SourceName = sourceName;
+            Details = details;
+            Method = method;
+            StackTrace = stackTrace;
+            SourceObject = sourceObject;
+            Depth = depth;
+        }
+
+        public ContextInfo WithDetails(string details, bool append = false)
+        {
+            string combined = details;
+            if (append && !string.IsNullOrEmpty(Details))
+            {
+                if (string.IsNullOrEmpty(details)) combined = Details;
+                else combined = Details + " → " + details;
+            }
+            return new ContextInfo(SourceType, SourceName, combined, Method, StackTrace, SourceObject, Depth);
+        }
+
+        public bool IsValid => !string.IsNullOrEmpty(SourceType) || !string.IsNullOrEmpty(SourceName) || SourceObject != null;
+
+        public string ComposeSummary()
+        {
+            var sb = new StringBuilder();
+            if (!string.IsNullOrEmpty(SourceType)) sb.Append(SourceType);
+            if (!string.IsNullOrEmpty(SourceName))
+            {
+                if (sb.Length > 0) sb.Append(" · ");
+                sb.Append(SourceName);
+            }
+            if (!string.IsNullOrEmpty(Details))
+            {
+                if (sb.Length > 0) sb.Append(" · ");
+                sb.Append(Details);
+            }
+            return sb.Length > 0 ? sb.ToString() : "(unknown)";
+        }
+    }
+
+    /// <summary>
+    /// Disposable scope helper used to temporarily override the context.
+    /// </summary>
+    public readonly struct Scope : IDisposable
+    {
+        private readonly ContextInfo? _previous;
+
+        public Scope(ContextInfo info)
+        {
+            _previous = _current.Value;
+            _current.Value = info;
+        }
+
+        public void Dispose()
+        {
+            _current.Value = _previous;
+        }
+    }
+
+    /// <summary>
+    /// Begins a temporary scope for the provided source.
+    /// </summary>
+    public static Scope BeginScope(UnityEngine.Object sourceObject, string sourceType, string sourceName, string details = null)
+    {
+        var depth = (_current.Value?.Depth ?? -1) + 1;
+        var info = new ContextInfo(sourceType, sourceName, details, CaptureMethodName(), CaptureStackTrace(), sourceObject, depth);
+        return new Scope(info);
+    }
+
+    /// <summary>
+    /// Returns the current scope, or captures the stack trace for the direct caller if no scope was provided.
+    /// </summary>
+    public static ContextInfo CaptureOrDefault(UnityEngine.Object fallbackObject, string sourceTypeFallback, string sourceNameFallback)
+    {
+        var ctx = _current.Value;
+        if (ctx.HasValue && ctx.Value.IsValid)
+        {
+            return ctx.Value;
+        }
+
+        var method = CaptureMethodName(skipBuiltin: true);
+        var trace = CaptureStackTrace();
+        var type = string.IsNullOrEmpty(sourceTypeFallback) ? "Code" : sourceTypeFallback;
+        string name = sourceNameFallback;
+        if (string.IsNullOrEmpty(name))
+        {
+            if (fallbackObject != null) name = fallbackObject.name;
+            else name = method ?? "Unknown";
+        }
+
+        return new ContextInfo(type, name, null, method, trace, fallbackObject, 0);
+    }
+
+    private static string CaptureMethodName(bool skipBuiltin = false)
+    {
+        try
+        {
+            var trace = new StackTrace(2, false);
+            for (int i = 0; i < trace.FrameCount; i++)
+            {
+                var frame = trace.GetFrame(i);
+                var method = frame?.GetMethod();
+                if (method == null) continue;
+                var declaringType = method.DeclaringType;
+                if (declaringType == null) continue;
+
+                if (skipBuiltin && (declaringType == typeof(UITweenPlayer) || declaringType == typeof(UITweenTrack) || declaringType == typeof(UITweenStateMachine) || declaringType == typeof(UITweenCallContext)))
+                {
+                    continue;
+                }
+
+                return declaringType.FullName + "." + method.Name;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+        return null;
+    }
+
+    private static string CaptureStackTrace()
+    {
+        try
+        {
+            return Environment.StackTrace;
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenCallContext.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenCallContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb9b84a1205f449b8cc1b789a9a2b37c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenMonitor.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenMonitor.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using UnityEngine;
+using DG.Tweening;
+
+/// <summary>
+/// Central runtime monitor that records the lifecycle of UITween animations.
+/// Thread-safe ring buffer with active mapping for live updates.
+/// </summary>
+public sealed class UITweenMonitor : ScriptableObject
+{
+    public const int Capacity = 512;
+    public const long InvalidId = 0;
+
+    public static UITweenMonitor Instance
+    {
+        get
+        {
+            if (_instance == null)
+            {
+                _instance = CreateInstance<UITweenMonitor>();
+                _instance.hideFlags = HideFlags.HideAndDontSave;
+            }
+            return _instance;
+        }
+    }
+
+    public event Action Changed;
+
+    private static UITweenMonitor _instance;
+    private readonly UITweenMonitorEntry[] _buffer = new UITweenMonitorEntry[Capacity];
+    private readonly Dictionary<long, int> _active = new();
+    private int _nextIndex;
+    private int _count;
+    private long _nextRequestId = InvalidId;
+    private readonly object _lock = new();
+
+    public enum EntryStatus
+    {
+        Pending,
+        Playing,
+        Completed,
+        Interrupted
+    }
+
+    [Serializable]
+    public struct UITweenMonitorEntry
+    {
+        public long requestId;
+        public EntryStatus status;
+        public double createdAt;
+        public double startedAt;
+        public double endedAt;
+        public int startFrame;
+        public int endFrame;
+        public string initiatorType;
+        public string initiatorName;
+        public string initiatorDetails;
+        public string initiatorMethod;
+        public string initiatorStack;
+        public UnityEngine.Object initiatorObject;
+        public string responderPath;
+        public string responderName;
+        public UnityEngine.Object responderObject;
+        public string presetName;
+        public bool reversed;
+        public float presetDuration;
+        public string interruptionReason;
+        public int tweenHash;
+
+        public bool IsActive => status == EntryStatus.Pending || status == EntryStatus.Playing;
+    }
+
+    public long Register(UITweenPlayer player, UITweenPreset preset, bool reversed, Tween tween, UITweenCallContext.ContextInfo context)
+    {
+        if (player == null) throw new ArgumentNullException(nameof(player));
+        var entry = new UITweenMonitorEntry
+        {
+            requestId = Interlocked.Increment(ref _nextRequestId),
+            status = EntryStatus.Pending,
+            createdAt = Time.realtimeSinceStartup,
+            startedAt = 0d,
+            endedAt = 0d,
+            startFrame = -1,
+            endFrame = -1,
+            initiatorType = context.SourceType ?? string.Empty,
+            initiatorName = context.SourceName ?? string.Empty,
+            initiatorDetails = context.Details ?? string.Empty,
+            initiatorMethod = context.Method ?? string.Empty,
+            initiatorStack = context.StackTrace ?? string.Empty,
+            initiatorObject = context.SourceObject,
+            responderObject = player,
+            responderName = player.name,
+            responderPath = BuildPath(player.transform),
+            presetName = preset != null ? preset.presetName : "<null>",
+            reversed = reversed,
+            presetDuration = preset != null ? preset.duration : 0f,
+            interruptionReason = string.Empty,
+            tweenHash = tween != null ? tween.GetHashCode() : 0
+        };
+
+        lock (_lock)
+        {
+            int index = _nextIndex;
+            _nextIndex = (_nextIndex + 1) % Capacity;
+            if (_count < Capacity) _count++;
+
+            ref var slot = ref _buffer[index];
+            if (slot.requestId != InvalidId)
+            {
+                _active.Remove(slot.requestId);
+            }
+
+            _buffer[index] = entry;
+            _active[entry.requestId] = index;
+        }
+
+        RaiseChanged();
+        return entry.requestId;
+    }
+
+    public void MarkStarted(long requestId)
+    {
+        bool changed = false;
+        lock (_lock)
+        {
+            if (_active.TryGetValue(requestId, out var index))
+            {
+                var entry = _buffer[index];
+                entry.status = EntryStatus.Playing;
+                entry.startedAt = Time.realtimeSinceStartup;
+                entry.startFrame = Time.frameCount;
+                _buffer[index] = entry;
+                changed = true;
+            }
+        }
+        if (changed) RaiseChanged();
+    }
+
+    public void MarkCompleted(long requestId)
+    {
+        bool changed = false;
+        lock (_lock)
+        {
+            if (_active.TryGetValue(requestId, out var index))
+            {
+                var entry = _buffer[index];
+                entry.status = EntryStatus.Completed;
+                entry.endedAt = Time.realtimeSinceStartup;
+                entry.endFrame = Time.frameCount;
+                _buffer[index] = entry;
+                _active.Remove(requestId);
+                changed = true;
+            }
+        }
+        if (changed) RaiseChanged();
+    }
+
+    public void MarkInterrupted(long requestId, string reason)
+    {
+        bool changed = false;
+        lock (_lock)
+        {
+            if (_active.TryGetValue(requestId, out var index))
+            {
+                var entry = _buffer[index];
+                entry.status = EntryStatus.Interrupted;
+                entry.endedAt = Time.realtimeSinceStartup;
+                entry.endFrame = Time.frameCount;
+                entry.interruptionReason = reason ?? string.Empty;
+                _buffer[index] = entry;
+                _active.Remove(requestId);
+                changed = true;
+            }
+        }
+        if (changed) RaiseChanged();
+    }
+
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            Array.Clear(_buffer, 0, _buffer.Length);
+            _active.Clear();
+            _count = 0;
+            _nextIndex = 0;
+            _nextRequestId = InvalidId;
+        }
+        RaiseChanged();
+    }
+
+    public void GetEntries(List<UITweenMonitorEntry> destination)
+    {
+        if (destination == null) throw new ArgumentNullException(nameof(destination));
+        lock (_lock)
+        {
+            destination.Clear();
+            if (_count == 0) return;
+
+            int index = (_nextIndex - _count + Capacity) % Capacity;
+            for (int i = 0; i < _count; i++)
+            {
+                int bufferIndex = (index + i) % Capacity;
+                var entry = _buffer[bufferIndex];
+                if (entry.requestId != InvalidId)
+                {
+                    destination.Add(entry);
+                }
+            }
+        }
+    }
+
+    public bool TryGetEntry(long requestId, out UITweenMonitorEntry entry)
+    {
+        lock (_lock)
+        {
+            if (_active.TryGetValue(requestId, out var index))
+            {
+                entry = _buffer[index];
+                return true;
+            }
+        }
+        entry = default;
+        return false;
+    }
+
+    public static string BuildPath(Transform transform)
+    {
+        if (transform == null) return string.Empty;
+        lock (_pathLock)
+        {
+            _sharedPathBuilder.Clear();
+            var stack = _sharedTransformStack;
+            stack.Clear();
+
+            var current = transform;
+            while (current != null)
+            {
+                stack.Push(current.name);
+                current = current.parent;
+            }
+
+            bool first = true;
+            while (stack.Count > 0)
+            {
+                if (!first) _sharedPathBuilder.Append('/');
+                _sharedPathBuilder.Append(stack.Pop());
+                first = false;
+            }
+
+            string path = _sharedPathBuilder.ToString();
+            _sharedPathBuilder.Clear();
+            return path;
+        }
+    }
+
+    private static readonly Stack<string> _sharedTransformStack = new();
+    private static readonly System.Text.StringBuilder _sharedPathBuilder = new System.Text.StringBuilder(256);
+    private static readonly object _pathLock = new();
+
+    private void RaiseChanged()
+    {
+        Changed?.Invoke();
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenMonitor.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenMonitor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a0f0d47a7094c63a5d70fa3437ea410
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenMonitorIMGUI.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenMonitorIMGUI.cs
@@ -1,0 +1,179 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Lightweight runtime IMGUI visualisation for the UITween monitor.
+/// </summary>
+[DefaultExecutionOrder(-10000)]
+public class UITweenMonitorIMGUI : MonoBehaviour
+{
+    private static UITweenMonitorIMGUI _instance;
+    private readonly List<UITweenMonitor.UITweenMonitorEntry> _entries = new();
+    private Rect _windowRect = new Rect(20f, 20f, 720f, 420f);
+    private Vector2 _scroll;
+    private bool _visible;
+    private string _search = string.Empty;
+    private bool _showPending = true;
+    private bool _showPlaying = true;
+    private bool _showCompleted = true;
+    private bool _showInterrupted = true;
+
+    public KeyCode toggleKey = KeyCode.F8;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void AutoCreate()
+    {
+        if (_instance != null) return;
+        var go = new GameObject("[UITweenMonitorIMGUI]");
+        DontDestroyOnLoad(go);
+        _instance = go.AddComponent<UITweenMonitorIMGUI>();
+        go.hideFlags = HideFlags.HideAndDontSave;
+    }
+
+    private void Awake()
+    {
+        if (_instance != null && _instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        _instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    private void Update()
+    {
+        if (Input.GetKeyDown(toggleKey))
+        {
+            _visible = !_visible;
+        }
+    }
+
+    private void OnGUI()
+    {
+        if (!_visible) return;
+        _windowRect = GUILayout.Window(GetInstanceID(), _windowRect, DrawWindow, "UITween Monitor", GUILayout.Width(720f), GUILayout.Height(420f));
+    }
+
+    private void DrawWindow(int id)
+    {
+        GUILayout.BeginHorizontal();
+        GUILayout.Label("Search", GUILayout.Width(60f));
+        _search = GUILayout.TextField(_search ?? string.Empty);
+        if (GUILayout.Button("×", GUILayout.Width(28f)))
+        {
+            _search = string.Empty;
+        }
+        GUILayout.FlexibleSpace();
+        if (GUILayout.Button("Close", GUILayout.Width(72f)))
+        {
+            _visible = false;
+        }
+        GUILayout.EndHorizontal();
+
+        GUILayout.BeginHorizontal();
+        ToggleFilter("Pending", ref _showPending);
+        ToggleFilter("Playing", ref _showPlaying);
+        ToggleFilter("Completed", ref _showCompleted);
+        ToggleFilter("Interrupted", ref _showInterrupted);
+        GUILayout.EndHorizontal();
+
+        var monitor = UITweenMonitor.Instance;
+        monitor.GetEntries(_entries);
+
+        string searchLower = string.IsNullOrEmpty(_search) ? null : _search.ToLowerInvariant();
+        double now = Time.realtimeSinceStartup;
+
+        _scroll = GUILayout.BeginScrollView(_scroll, false, true);
+        foreach (var entry in _entries)
+        {
+            if (!IsStatusVisible(entry.status)) continue;
+            if (!PassesSearch(entry, searchLower)) continue;
+            DrawEntry(entry, now);
+        }
+        GUILayout.EndScrollView();
+
+        GUILayout.Label("Toggle with " + toggleKey + " · Entries: " + _entries.Count, EditorStylesLike.SmallLabel);
+        GUI.DragWindow();
+    }
+
+    private bool IsStatusVisible(UITweenMonitor.EntryStatus status)
+    {
+        return (status == UITweenMonitor.EntryStatus.Pending && _showPending)
+            || (status == UITweenMonitor.EntryStatus.Playing && _showPlaying)
+            || (status == UITweenMonitor.EntryStatus.Completed && _showCompleted)
+            || (status == UITweenMonitor.EntryStatus.Interrupted && _showInterrupted);
+    }
+
+    private bool PassesSearch(in UITweenMonitor.UITweenMonitorEntry entry, string searchLower)
+    {
+        if (string.IsNullOrEmpty(searchLower)) return true;
+        if (!string.IsNullOrEmpty(entry.presetName) && entry.presetName.ToLowerInvariant().Contains(searchLower)) return true;
+        if (!string.IsNullOrEmpty(entry.responderName) && entry.responderName.ToLowerInvariant().Contains(searchLower)) return true;
+        if (!string.IsNullOrEmpty(entry.responderPath) && entry.responderPath.ToLowerInvariant().Contains(searchLower)) return true;
+        if (!string.IsNullOrEmpty(entry.initiatorName) && entry.initiatorName.ToLowerInvariant().Contains(searchLower)) return true;
+        if (!string.IsNullOrEmpty(entry.initiatorDetails) && entry.initiatorDetails.ToLowerInvariant().Contains(searchLower)) return true;
+        if (!string.IsNullOrEmpty(entry.initiatorType) && entry.initiatorType.ToLowerInvariant().Contains(searchLower)) return true;
+        return false;
+    }
+
+    private void DrawEntry(in UITweenMonitor.UITweenMonitorEntry entry, double now)
+    {
+        GUILayout.BeginVertical("box");
+        GUILayout.Label(string.Format("#{0} · {1} · {2}{3}",
+            entry.requestId,
+            entry.status,
+            entry.presetName,
+            entry.reversed ? " (Reversed)" : string.Empty));
+
+        double start = entry.startedAt > 0.0 ? entry.startedAt : entry.createdAt;
+        double end = entry.endedAt > 0.0 ? entry.endedAt : now;
+        double duration = Mathf.Max(0f, (float)(end - start));
+        GUILayout.Label(string.Format("Duration: {0:0.000}s  Frames: {1} → {2}", duration, entry.startFrame, entry.endFrame));
+
+        GUILayout.Label("Responder: " + entry.responderName + " · " + entry.responderPath);
+        GUILayout.Label("Initiator: " + BuildInitiatorLine(entry));
+        if (!string.IsNullOrEmpty(entry.interruptionReason))
+        {
+            GUILayout.Label("Reason: " + entry.interruptionReason);
+        }
+
+        GUILayout.EndVertical();
+    }
+
+    private string BuildInitiatorLine(in UITweenMonitor.UITweenMonitorEntry entry)
+    {
+        var pieces = new List<string>(3);
+        if (!string.IsNullOrEmpty(entry.initiatorType)) pieces.Add(entry.initiatorType);
+        if (!string.IsNullOrEmpty(entry.initiatorName)) pieces.Add(entry.initiatorName);
+        if (!string.IsNullOrEmpty(entry.initiatorDetails)) pieces.Add(entry.initiatorDetails);
+        if (pieces.Count == 0 && !string.IsNullOrEmpty(entry.initiatorMethod)) pieces.Add(entry.initiatorMethod);
+        return string.Join(" · ", pieces);
+    }
+
+    private void ToggleFilter(string label, ref bool value)
+    {
+        value = GUILayout.Toggle(value, label, GUILayout.Width(110f));
+    }
+
+    private static class EditorStylesLike
+    {
+        private static GUIStyle _smallLabel;
+        public static GUIStyle SmallLabel
+        {
+            get
+            {
+                if (_smallLabel == null)
+                {
+                    _smallLabel = new GUIStyle(GUI.skin.label)
+                    {
+                        fontSize = 11,
+                        alignment = TextAnchor.MiddleLeft,
+                        normal = { textColor = Color.gray }
+                    };
+                }
+                return _smallLabel;
+            }
+        }
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenMonitorIMGUI.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenMonitorIMGUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 882ff73b6d09452fb67b8864c8ad1ea7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenPlayer.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenPlayer.cs
@@ -46,10 +46,26 @@ public class UITweenPlayer : MonoBehaviour
     readonly Dictionary<UITweenPreset, Baseline> _baselines = new();
     
     private bool _isLocked = false;
+    private string _pendingMonitorKillReason;
 
     public bool IsLocked => _isLocked;
     public void Lock() => _isLocked = true;
     public void Unlock() => _isLocked = false;
+
+    private void PrepareMonitorKillReason(string reason)
+    {
+        _pendingMonitorKillReason = reason;
+    }
+
+    private static string DescribePlayRequest(UITweenPreset preset, bool reversed, bool master)
+    {
+        string name = preset != null ? preset.presetName : "<null>";
+        if (master)
+        {
+            return reversed ? $"MasterReversed({name})" : $"MasterPlay({name})";
+        }
+        return reversed ? $"PlayReversed({name})" : $"Play({name})";
+    }
 
     void Awake()
     {
@@ -73,8 +89,16 @@ public class UITweenPlayer : MonoBehaviour
     {
         if (_active != null && _active.IsActive())
         {
+            if (string.IsNullOrEmpty(_pendingMonitorKillReason))
+            {
+                _pendingMonitorKillReason = complete ? "Kill (complete)" : "Kill (manual)";
+            }
             _active.Kill(complete);
             _active = null;
+        }
+        else
+        {
+            _pendingMonitorKillReason = null;
         }
         LastPreparedSequence = null;
     }
@@ -97,17 +121,17 @@ public class UITweenPlayer : MonoBehaviour
     
     private Tween PlayMasterCore(UITweenPreset preset, bool reversed)
     {
+        PrepareMonitorKillReason($"Superseded by {DescribePlayRequest(preset, reversed, true)}");
         Kill(false);
         Lock();
 
-        var seq = CreateAnimationSequence(preset, reversed);
+        var seq = CreateAnimationSequence(preset, reversed, true);
         if (seq != null)
         {
-            seq.OnComplete(Unlock); 
             _active = seq.Play();
             return _active;
         }
-        
+
         Unlock();
         return null;
     }
@@ -115,9 +139,10 @@ public class UITweenPlayer : MonoBehaviour
     private void PlayCore(UITweenPreset preset, bool reversed)
     {
         if (IsLocked) return;
+        PrepareMonitorKillReason($"Superseded by {DescribePlayRequest(preset, reversed, false)}");
         Kill(false);
 
-        var seq = CreateAnimationSequence(preset, reversed);
+        var seq = CreateAnimationSequence(preset, reversed, false);
         if (seq != null)
         {
             _active = seq.Play();
@@ -139,7 +164,7 @@ public class UITweenPlayer : MonoBehaviour
         };
     }
 
-    private Sequence CreateAnimationSequence(UITweenPreset preset, bool reversed)
+    private Sequence CreateAnimationSequence(UITweenPreset preset, bool reversed, bool master)
     {
         if (preset == null || _rt == null) return null;
 
@@ -253,7 +278,41 @@ public class UITweenPlayer : MonoBehaviour
         LastPreparedSequence = seq;
         SequencePrepared?.Invoke(preset, reversed, seq);
 
-        seq.OnStart(() => onPlay?.Invoke()).OnComplete(() => onComplete?.Invoke());
+        var context = UITweenCallContext.CaptureOrDefault(this, "UITweenPlayer", gameObject != null ? gameObject.name : null);
+        context = context.WithDetails(DescribePlayRequest(preset, reversed, master), append: true);
+        var monitor = UITweenMonitor.Instance;
+        var requestId = monitor.Register(this, preset, reversed, seq, context);
+
+        seq.OnStart(() =>
+        {
+            monitor.MarkStarted(requestId);
+            onPlay?.Invoke();
+        });
+
+        seq.OnComplete(() =>
+        {
+            monitor.MarkCompleted(requestId);
+            _pendingMonitorKillReason = null;
+            if (master)
+            {
+                Unlock();
+            }
+            onComplete?.Invoke();
+        });
+
+        seq.OnKill(() =>
+        {
+            if (!seq.IsComplete())
+            {
+                var reason = string.IsNullOrEmpty(_pendingMonitorKillReason) ? "Killed" : _pendingMonitorKillReason;
+                monitor.MarkInterrupted(requestId, reason);
+                if (master)
+                {
+                    Unlock();
+                }
+            }
+            _pendingMonitorKillReason = null;
+        });
 
         return seq;
     }

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenStateMachine.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenStateMachine.cs
@@ -67,23 +67,20 @@ public class UITweenStateMachine : MonoBehaviour, IPointerEnterHandler, IPointer
         var oldBinding = FindBinding(_currentState);
         if (oldBinding != null)
         {
-            // 檢查是否應倒播進入動畫
             if (oldBinding.reverseOnExit && !string.IsNullOrEmpty(oldBinding.onEnterPresetName))
             {
-                _player.PlayReversedByName(oldBinding.onEnterPresetName);
+                PlayStateAnimation("Exit", oldBinding.onEnterPresetName, true, _currentState, newState);
             }
-            // 否則，播放指定的退出動畫
             else if (!string.IsNullOrEmpty(oldBinding.onExitPresetName))
             {
-                _player.PlayByName(oldBinding.onExitPresetName);
+                PlayStateAnimation("Exit", oldBinding.onExitPresetName, false, _currentState, newState);
             }
         }
-        
-        // 查找新狀態的綁定，播放進入動畫（此部分邏輯不變）
+
         var newBinding = FindBinding(newState);
-        if (newBinding != null && !string.IsNullOrEmpty(newBinding.onEnterPresetName))
+        if (newBinding != null)
         {
-            _player.PlayByName(newBinding.onEnterPresetName);
+            PlayStateAnimation("Enter", newBinding.onEnterPresetName, false, _currentState, newState);
         }
 
         _currentState = newState;
@@ -163,6 +160,24 @@ public class UITweenStateMachine : MonoBehaviour, IPointerEnterHandler, IPointer
         else
         {
             if (_currentState == UIState.Disabled) TransitionTo(UIState.Normal);
+        }
+    }
+
+    private void PlayStateAnimation(string phase, string presetName, bool reversed, UIState fromState, UIState toState)
+    {
+        if (string.IsNullOrEmpty(presetName)) return;
+        string transitionLabel = fromState + "→" + toState;
+        string detail = phase + " " + transitionLabel + " · " + presetName + (reversed ? " (Reversed)" : string.Empty);
+        using (UITweenCallContext.BeginScope(this, "StateMachine", gameObject != null ? gameObject.name : name, detail))
+        {
+            if (reversed)
+            {
+                _player.PlayReversedByName(presetName);
+            }
+            else
+            {
+                _player.PlayByName(presetName);
+            }
         }
     }
 }

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenTrack.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenTrack.cs
@@ -126,11 +126,17 @@ public class UITweenTrack : MonoBehaviour
 
     IEnumerator RunTrack(int trackIndex, Track track)
     {
-        foreach (var item in track.items)
+        for (int itemIndex = 0; itemIndex < track.items.Count; itemIndex++)
         {
+            var item = track.items[itemIndex];
             if (item == null || item.player == null) continue;
 
-            var tween = item.player.PlayMasterByName(item.presetName);
+            Tween tween;
+            string sourceName = string.IsNullOrEmpty(track.trackName) ? gameObject.name : track.trackName;
+            using (UITweenCallContext.BeginScope(this, "Track", sourceName, BuildTrackDetail(itemIndex, item)))
+            {
+                tween = item.player.PlayMasterByName(item.presetName);
+            }
 
             if (playFlow == PlayFlow.SequentialWait)
             {
@@ -148,6 +154,13 @@ public class UITweenTrack : MonoBehaviour
             }
         }
         _runningTracks.Remove(trackIndex);
+    }
+
+    private string BuildTrackDetail(int itemIndex, TrackItem item)
+    {
+        string preset = item != null && !string.IsNullOrEmpty(item.presetName) ? item.presetName : "<none>";
+        string playerName = item != null && item.player != null ? item.player.name : "<missing player>";
+        return $"Item #{itemIndex + 1} · {playerName} · {preset}";
     }
 
 


### PR DESCRIPTION
## Summary
- add UITweenCallContext and UITweenMonitor runtime utilities to capture tween requests and lifecycle data
- instrument UITweenPlayer/Track/StateMachine to report caller context and playback status to the monitor
- add runtime IMGUI overlay and editor window for filtering and inspecting recorded tween events

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ef9048e6f48329a6ffedee0f4b63db