### PR TITLE
feat: add UI choreography state graph system

### DIFF
--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/IUIActorGoalApplier.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/IUIActorGoalApplier.cs
@@ -1,0 +1,11 @@
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// Interface that allows custom components to respond when a UIActor receives a schedule.
+    /// Implementations can update transforms, invoke tween players, etc.
+    /// </summary>
+    public interface IUIActorGoalApplier
+    {
+        void Apply(UIActor actor, UIActorSchedule schedule);
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/IUIActorStyleHandler.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/IUIActorStyleHandler.cs
@@ -1,0 +1,10 @@
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// Optional interface for components that change visual styles when a UIActor switches role/state.
+    /// </summary>
+    public interface IUIActorStyleHandler
+    {
+        void ApplyStyle(UIActor actor, string styleVariant, string phaseName);
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/RectTransformSnapshot.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/RectTransformSnapshot.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// Serializable snapshot of a RectTransform's geometric state. Used to describe anchor targets for actors.
+    /// </summary>
+    [System.Serializable]
+    public struct RectTransformSnapshot
+    {
+        public Vector2 anchoredPosition;
+        public Vector2 sizeDelta;
+        public Vector3 localScale;
+        public Vector3 eulerAngles;
+        public Vector2 pivot;
+        public Vector2 anchorMin;
+        public Vector2 anchorMax;
+
+        public static RectTransformSnapshot FromRectTransform(RectTransform rect)
+        {
+            return new RectTransformSnapshot
+            {
+                anchoredPosition = rect.anchoredPosition,
+                sizeDelta = rect.sizeDelta,
+                localScale = rect.localScale,
+                eulerAngles = rect.localEulerAngles,
+                pivot = rect.pivot,
+                anchorMin = rect.anchorMin,
+                anchorMax = rect.anchorMax
+            };
+        }
+
+        public void ApplyTo(RectTransform rect)
+        {
+            rect.anchorMin = anchorMin;
+            rect.anchorMax = anchorMax;
+            rect.pivot = pivot;
+            rect.localEulerAngles = eulerAngles;
+            rect.localScale = localScale;
+            rect.sizeDelta = sizeDelta;
+            rect.anchoredPosition = anchoredPosition;
+        }
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIActor.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIActor.cs
@@ -1,0 +1,282 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// Component that represents an animatable UI element participating in global choreography.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(RectTransform))]
+    public class UIActor : MonoBehaviour
+    {
+        [Header("Identity")]
+        [SerializeField]
+        private string _actorId;
+
+        [SerializeField]
+        private string _choreoTag;
+
+        [SerializeField]
+        private float _choreoWeight = 0f;
+
+        [SerializeField]
+        private bool _autoRegister = true;
+
+        [Header("Visibility Control")]
+        [SerializeField]
+        private bool _reactivateOnEnter = true;
+
+        [SerializeField]
+        private bool _deactivateAfterExit = true;
+
+        [SerializeField]
+        private bool _useCanvasGroupVisibility = true;
+
+        [SerializeField]
+        private CanvasGroup _visibilityCanvasGroup;
+
+        [Header("Preset Mapping")]
+        [SerializeField]
+        private List<RolePresetCollection> _rolePresets = new List<RolePresetCollection>();
+
+        [SerializeField]
+        private List<PhasePreset> _globalPhasePresets = new List<PhasePreset>();
+
+        [SerializeField]
+        private string _fallbackEnterPreset;
+
+        [SerializeField]
+        private string _fallbackExitPreset;
+
+        [Header("Events")]
+        public UnityEvent<UIActorSchedule> onScheduleReceived;
+        public UnityEvent<string> onStyleVariantChanged;
+
+        private RectTransform _rectTransform;
+        private IUIActorGoalApplier[] _goalAppliers;
+        private IUIActorStyleHandler[] _styleHandlers;
+        private Coroutine _pendingDeactivate;
+
+        public string ActorId => _actorId;
+        public string ChoreoTag => _choreoTag;
+        public float ChoreoWeight => _choreoWeight;
+        public RectTransform RectTransform => _rectTransform;
+
+        private void Awake()
+        {
+            _rectTransform = GetComponent<RectTransform>();
+            if (_visibilityCanvasGroup == null && _useCanvasGroupVisibility)
+            {
+                _visibilityCanvasGroup = GetComponent<CanvasGroup>();
+            }
+            CacheHandlers();
+        }
+
+        private void CacheHandlers()
+        {
+            _goalAppliers = GetComponents<IUIActorGoalApplier>();
+            _styleHandlers = GetComponents<IUIActorStyleHandler>();
+        }
+
+        private void OnEnable()
+        {
+            if (_autoRegister)
+            {
+                EnsureOrchestrator()?.RegisterActor(this);
+            }
+
+            UIEventBus.ActorScheduled += OnActorScheduled;
+        }
+
+        private void OnDisable()
+        {
+            UIEventBus.ActorScheduled -= OnActorScheduled;
+            if (_autoRegister)
+            {
+                EnsureOrchestrator()?.UnregisterActor(this);
+            }
+        }
+
+        private UIOrchestrator EnsureOrchestrator()
+        {
+            if (UIOrchestrator.Instance != null)
+            {
+                return UIOrchestrator.Instance;
+            }
+
+#if UNITY_2023_1_OR_NEWER
+            return FindFirstObjectByType<UIOrchestrator>();
+#else
+            return FindObjectOfType<UIOrchestrator>();
+#endif
+        }
+
+        private void OnActorScheduled(UIActorSchedule schedule)
+        {
+            if (schedule.actorId != _actorId)
+            {
+                return;
+            }
+
+            HandleSchedule(schedule);
+        }
+
+        private void HandleSchedule(UIActorSchedule schedule)
+        {
+            if (_reactivateOnEnter && schedule.targetVisible)
+            {
+                if (!gameObject.activeSelf)
+                {
+                    gameObject.SetActive(true);
+                }
+            }
+
+            onScheduleReceived?.Invoke(schedule);
+            if (!string.IsNullOrEmpty(schedule.styleVariant))
+            {
+                onStyleVariantChanged?.Invoke(schedule.styleVariant);
+                if (_styleHandlers != null)
+                {
+                    for (int i = 0; i < _styleHandlers.Length; i++)
+                    {
+                        _styleHandlers[i]?.ApplyStyle(this, schedule.styleVariant, schedule.phaseName);
+                    }
+                }
+            }
+
+            if (_goalAppliers != null && _goalAppliers.Length > 0)
+            {
+                for (int i = 0; i < _goalAppliers.Length; i++)
+                {
+                    _goalAppliers[i]?.Apply(this, schedule);
+                }
+            }
+            else if (schedule.hasSnapshot)
+            {
+                schedule.snapshot.ApplyTo(_rectTransform);
+            }
+
+            if (_useCanvasGroupVisibility && _visibilityCanvasGroup != null)
+            {
+                _visibilityCanvasGroup.interactable = schedule.targetVisible;
+                _visibilityCanvasGroup.blocksRaycasts = schedule.targetVisible;
+            }
+
+            if (!schedule.targetVisible && _deactivateAfterExit && schedule.isExitPhase && !schedule.isEnterPhase)
+            {
+                if (_pendingDeactivate != null)
+                {
+                    StopCoroutine(_pendingDeactivate);
+                }
+                _pendingDeactivate = StartCoroutine(DeactivateAfter(schedule.durationHint, schedule.useUnscaledTime));
+            }
+        }
+
+        private IEnumerator DeactivateAfter(float delay, bool unscaled)
+        {
+            if (delay > 0f)
+            {
+                if (unscaled)
+                {
+                    yield return new WaitForSecondsRealtime(delay);
+                }
+                else
+                {
+                    yield return new WaitForSeconds(delay);
+                }
+            }
+
+            gameObject.SetActive(false);
+            _pendingDeactivate = null;
+        }
+
+        public string ResolvePreset(string roleId, string phaseName)
+        {
+            if (!string.IsNullOrEmpty(phaseName))
+            {
+                for (int i = 0; i < _globalPhasePresets.Count; i++)
+                {
+                    var preset = _globalPhasePresets[i];
+                    if (preset != null && preset.phaseName == phaseName && !string.IsNullOrEmpty(preset.presetKey))
+                    {
+                        return preset.presetKey;
+                    }
+                }
+            }
+
+            if (!string.IsNullOrEmpty(roleId))
+            {
+                for (int i = 0; i < _rolePresets.Count; i++)
+                {
+                    var collection = _rolePresets[i];
+                    if (collection != null && collection.roleId == roleId)
+                    {
+                        string rolePreset = collection.Resolve(phaseName);
+                        if (!string.IsNullOrEmpty(rolePreset))
+                        {
+                            return rolePreset;
+                        }
+                    }
+                }
+            }
+
+            if (IsExitPhase(phaseName))
+            {
+                return _fallbackExitPreset;
+            }
+
+            return _fallbackEnterPreset;
+        }
+
+        private static bool IsExitPhase(string phaseName)
+        {
+            if (string.IsNullOrEmpty(phaseName))
+            {
+                return false;
+            }
+
+            return phaseName.IndexOf("exit", System.StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        [System.Serializable]
+        public class PhasePreset
+        {
+            public string phaseName;
+            public string presetKey;
+        }
+
+        [System.Serializable]
+        public class RolePresetCollection
+        {
+            public string roleId;
+            public string defaultEnterPreset;
+            public string defaultExitPreset;
+            public List<PhasePreset> overrides = new List<PhasePreset>();
+
+            public string Resolve(string phaseName)
+            {
+                if (!string.IsNullOrEmpty(phaseName))
+                {
+                    for (int i = 0; i < overrides.Count; i++)
+                    {
+                        var entry = overrides[i];
+                        if (entry != null && entry.phaseName == phaseName && !string.IsNullOrEmpty(entry.presetKey))
+                        {
+                            return entry.presetKey;
+                        }
+                    }
+                }
+
+                if (IsExitPhase(phaseName))
+                {
+                    return defaultExitPreset;
+                }
+
+                return defaultEnterPreset;
+            }
+        }
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIAnchorRegistry.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIAnchorRegistry.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// Central registry that exposes lookup services for UI role anchors at runtime.
+    /// Anchors are registered automatically by the <see cref="UIRoleAnchor"/> component.
+    /// </summary>
+    public static class UIAnchorRegistry
+    {
+        private static readonly Dictionary<string, UIRoleAnchor> _anchors = new Dictionary<string, UIRoleAnchor>();
+
+        /// <summary>
+        /// Registers (or replaces) an anchor in the global registry.
+        /// </summary>
+        public static void Register(UIRoleAnchor anchor)
+        {
+            if (anchor == null || string.IsNullOrEmpty(anchor.AnchorId))
+            {
+                return;
+            }
+
+            _anchors[anchor.AnchorId] = anchor;
+        }
+
+        /// <summary>
+        /// Removes an anchor from the global registry.
+        /// </summary>
+        public static void Unregister(UIRoleAnchor anchor)
+        {
+            if (anchor == null || string.IsNullOrEmpty(anchor.AnchorId))
+            {
+                return;
+            }
+
+            if (_anchors.TryGetValue(anchor.AnchorId, out var existing) && ReferenceEquals(existing, anchor))
+            {
+                _anchors.Remove(anchor.AnchorId);
+            }
+        }
+
+        /// <summary>
+        /// Tries to locate an anchor by its identifier.
+        /// </summary>
+        public static bool TryGetAnchor(string anchorId, out UIRoleAnchor anchor)
+        {
+            if (!string.IsNullOrEmpty(anchorId))
+            {
+                return _anchors.TryGetValue(anchorId, out anchor);
+            }
+
+            anchor = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Captures a snapshot of a registered anchor's RectTransform.
+        /// </summary>
+        public static bool TryGetSnapshot(string anchorId, out RectTransformSnapshot snapshot)
+        {
+            snapshot = default;
+            if (TryGetAnchor(anchorId, out var anchor) && anchor != null)
+            {
+                var rect = anchor.GetRectTransform();
+                if (rect != null)
+                {
+                    snapshot = RectTransformSnapshot.FromRectTransform(rect);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIConductor.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIConductor.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections;
+using UnityEngine;
+
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// Executes transition plans by publishing phase and actor schedule events over time.
+    /// </summary>
+    public class UIConductor : MonoBehaviour
+    {
+        [SerializeField]
+        private bool _useUnscaledClock = true;
+
+        private Coroutine _running;
+        private UITransitionPlan _currentPlan;
+        private Action<UITransitionPlan> _onCompleted;
+
+        public void ExecutePlan(UITransitionPlan plan, Action<UITransitionPlan> onCompleted)
+        {
+            if (plan == null)
+            {
+                return;
+            }
+
+            CancelCurrentPlan(UITransitionLifecycle.Cancelled);
+
+            _currentPlan = plan;
+            _onCompleted = onCompleted;
+            _running = StartCoroutine(RunPlan(plan));
+        }
+
+        public void CancelCurrentPlan(UITransitionLifecycle reason)
+        {
+            if (_running != null)
+            {
+                StopCoroutine(_running);
+                _running = null;
+            }
+
+            if (_currentPlan != null)
+            {
+                UIEventBus.PublishLifecycle(new UITransitionLifecycleEvent(_currentPlan.transitionId, _currentPlan.fromStateId, _currentPlan.toStateId, reason, _currentPlan.profile));
+            }
+
+            _currentPlan = null;
+            _onCompleted = null;
+        }
+
+        private IEnumerator RunPlan(UITransitionPlan plan)
+        {
+            float cursor = 0f;
+            foreach (var phase in plan.phases)
+            {
+                float wait = Mathf.Max(0f, phase.startTime - cursor);
+                if (wait > 0f)
+                {
+                    yield return Wait(wait, _useUnscaledClock);
+                }
+
+                cursor = phase.startTime;
+                UIEventBus.PublishPhase(new UIPhaseEvent(plan.transitionId, phase.phaseName, UIPhaseEventType.PhaseStarted, cursor, phase.duration));
+
+                foreach (var schedule in phase.actorSchedules)
+                {
+                    StartCoroutine(DispatchSchedule(schedule));
+                }
+
+                if (phase.duration > 0f)
+                {
+                    yield return Wait(phase.duration, _useUnscaledClock);
+                }
+
+                cursor += phase.duration;
+                UIEventBus.PublishPhase(new UIPhaseEvent(plan.transitionId, phase.phaseName, UIPhaseEventType.PhaseCompleted, cursor, phase.duration));
+            }
+
+            _running = null;
+            var completedPlan = plan;
+            _currentPlan = null;
+            var callback = _onCompleted;
+            _onCompleted = null;
+            callback?.Invoke(completedPlan);
+        }
+
+        private IEnumerator DispatchSchedule(UIActorSchedule schedule)
+        {
+            if (schedule.localDelay > 0f)
+            {
+                yield return Wait(schedule.localDelay, schedule.useUnscaledTime);
+            }
+
+            UIEventBus.PublishSchedule(schedule);
+        }
+
+        private static YieldInstruction Wait(float duration, bool unscaled)
+        {
+            if (duration <= 0f)
+            {
+                return null;
+            }
+
+            return unscaled ? new WaitForSecondsRealtime(duration) : new WaitForSeconds(duration);
+        }
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIEventBus.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIEventBus.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// Lightweight event bus dedicated to the UI choreography system.
+    /// Actors subscribe to high-level events instead of invoking each other directly.
+    /// </summary>
+    public static class UIEventBus
+    {
+        public static event Action<UITransitionCommand> TransitionRequested;
+        public static event Action<UITransitionLifecycleEvent> TransitionLifecycleChanged;
+        public static event Action<UIPhaseEvent> PhaseEventRaised;
+        public static event Action<UIActorSchedule> ActorScheduled;
+
+        public static void Publish(UITransitionCommand command)
+        {
+            TransitionRequested?.Invoke(command);
+        }
+
+        public static void PublishLifecycle(UITransitionLifecycleEvent lifecycleEvent)
+        {
+            TransitionLifecycleChanged?.Invoke(lifecycleEvent);
+        }
+
+        public static void PublishPhase(UIPhaseEvent phaseEvent)
+        {
+            PhaseEventRaised?.Invoke(phaseEvent);
+        }
+
+        public static void PublishSchedule(UIActorSchedule schedule)
+        {
+            ActorScheduled?.Invoke(schedule);
+        }
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIOrchestrator.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIOrchestrator.cs
@@ -1,0 +1,572 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// High-level service that resolves transition commands into concrete schedules and feeds them to the conductor.
+    /// </summary>
+    [DefaultExecutionOrder(-200)]
+    public class UIOrchestrator : MonoBehaviour
+    {
+        public static UIOrchestrator Instance { get; private set; }
+
+        [SerializeField]
+        private UIStateGraphAsset _stateGraph;
+
+        [SerializeField]
+        private string _initialStateId;
+
+        [SerializeField]
+        private bool _autoEnterInitialState = true;
+
+        [SerializeField]
+        private UIConductor _conductor;
+
+        [SerializeField]
+        private bool _useUnscaledTime = true;
+
+        private readonly Dictionary<string, UIActor> _actors = new Dictionary<string, UIActor>();
+        private UIStateProfile _currentStateProfile;
+        private string _currentStateId;
+        private UITransitionPlan _activePlan;
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Debug.LogWarning("Multiple UIOrchestrators detected. Only the first instance will be used.", this);
+            }
+            else
+            {
+                Instance = this;
+            }
+
+            if (_conductor == null)
+            {
+                _conductor = GetComponentInChildren<UIConductor>();
+            }
+        }
+
+        private void OnEnable()
+        {
+            UIEventBus.TransitionRequested += OnTransitionRequested;
+        }
+
+        private void OnDisable()
+        {
+            UIEventBus.TransitionRequested -= OnTransitionRequested;
+        }
+
+        private void Start()
+        {
+            if (!string.IsNullOrEmpty(_initialStateId))
+            {
+                if (_stateGraph != null && _stateGraph.TryGetState(_initialStateId, out var state))
+                {
+                    _currentStateId = _initialStateId;
+                    _currentStateProfile = state;
+                }
+
+                if (_autoEnterInitialState)
+                {
+                    RequestTransition(_initialStateId, "Initial");
+                }
+            }
+        }
+
+        public void RegisterActor(UIActor actor)
+        {
+            if (actor == null || string.IsNullOrEmpty(actor.ActorId))
+            {
+                return;
+            }
+
+            _actors[actor.ActorId] = actor;
+        }
+
+        public void UnregisterActor(UIActor actor)
+        {
+            if (actor == null || string.IsNullOrEmpty(actor.ActorId))
+            {
+                return;
+            }
+
+            if (_actors.TryGetValue(actor.ActorId, out var existing) && ReferenceEquals(existing, actor))
+            {
+                _actors.Remove(actor.ActorId);
+            }
+        }
+
+        private void OnTransitionRequested(UITransitionCommand command)
+        {
+            if (command == null)
+            {
+                return;
+            }
+
+            RequestTransition(command.toStateId, command.reason, command.payload);
+        }
+
+        public void RequestTransition(string toStateId, string reason = null, object payload = null)
+        {
+            if (string.IsNullOrEmpty(toStateId))
+            {
+                Debug.LogWarning("[UIOrchestrator] toStateId is null or empty.", this);
+                return;
+            }
+
+            if (_stateGraph == null)
+            {
+                Debug.LogError("[UIOrchestrator] State graph not assigned.", this);
+                return;
+            }
+
+            string fromStateId = _currentStateId;
+            UIStateProfile fromProfile = _currentStateProfile;
+            _stateGraph.TryGetState(toStateId, out var toProfile);
+
+            if (!_stateGraph.TryGetTransition(fromStateId, toStateId, out var transitionProfile))
+            {
+                transitionProfile = ResolveFallbackTransition(fromStateId, toStateId);
+                if (transitionProfile == null)
+                {
+                    Debug.LogWarning($"[UIOrchestrator] No transition profile found for {fromStateId} -> {toStateId}.", this);
+                    return;
+                }
+            }
+
+            string transitionId = Guid.NewGuid().ToString("N");
+
+            UIEventBus.PublishLifecycle(new UITransitionLifecycleEvent(transitionId, fromStateId, toStateId, UITransitionLifecycle.Requested, transitionProfile));
+
+            var plan = BuildPlan(transitionId, fromStateId, fromProfile, toStateId, toProfile, transitionProfile, payload);
+            if (plan == null)
+            {
+                Debug.LogWarning("[UIOrchestrator] Failed to build transition plan.", this);
+                return;
+            }
+
+            _activePlan = plan;
+            UIEventBus.PublishLifecycle(new UITransitionLifecycleEvent(transitionId, fromStateId, toStateId, UITransitionLifecycle.Planned, transitionProfile));
+            if (_conductor != null)
+            {
+                _conductor.ExecutePlan(plan, OnTransitionCompleted);
+                UIEventBus.PublishLifecycle(new UITransitionLifecycleEvent(transitionId, fromStateId, toStateId, UITransitionLifecycle.Started, transitionProfile));
+            }
+            else
+            {
+                Debug.LogError("[UIOrchestrator] No conductor assigned to execute plan.", this);
+            }
+        }
+
+        private void OnTransitionCompleted(UITransitionPlan plan)
+        {
+            if (plan == null)
+            {
+                return;
+            }
+
+            if (_stateGraph != null && _stateGraph.TryGetState(plan.toStateId, out var newState))
+            {
+                _currentStateId = plan.toStateId;
+                _currentStateProfile = newState;
+            }
+
+            UIEventBus.PublishLifecycle(new UITransitionLifecycleEvent(plan.transitionId, plan.fromStateId, plan.toStateId, UITransitionLifecycle.Completed, plan.profile));
+        }
+
+        private UITransitionPlan BuildPlan(string transitionId, string fromStateId, UIStateProfile fromProfile, string toStateId, UIStateProfile toProfile, UITransitionProfile profile, object payload)
+        {
+            if (profile == null)
+            {
+                return null;
+            }
+
+            var plan = new UITransitionPlan(transitionId, fromStateId, toStateId, profile);
+            var contexts = BuildActorContexts(fromProfile, toProfile);
+
+            float currentTime = 0f;
+            foreach (var phase in profile.phases)
+            {
+                currentTime += Mathf.Max(0f, phase.preDelay);
+                var phaseSchedule = new UIPhaseSchedule
+                {
+                    phaseName = phase.phaseName,
+                    startTime = currentTime
+                };
+
+                var participants = FilterParticipants(contexts, phase);
+                SortParticipants(participants, phase);
+                var offsets = ComputeOffsets(participants.Count, phase);
+
+                float lastOffset = 0f;
+                for (int i = 0; i < participants.Count; i++)
+                {
+                    var context = participants[i];
+                    var binding = SelectBindingForPhase(context, phase.role);
+                    if (binding == null)
+                    {
+                        continue;
+                    }
+
+                    float offset = offsets != null && i < offsets.Count ? offsets[i] : 0f;
+                    lastOffset = Mathf.Max(lastOffset, offset);
+
+                    var schedule = BuildActorSchedule(plan, phase, context, binding, phaseSchedule.startTime, offset);
+                    phaseSchedule.actorSchedules.Add(schedule);
+                }
+
+                phaseSchedule.duration = Mathf.Max(phase.minimumDuration, lastOffset + phase.tailHold);
+                currentTime = phaseSchedule.startTime + phaseSchedule.duration;
+                plan.phases.Add(phaseSchedule);
+            }
+
+            return plan;
+        }
+
+        private UITransitionProfile ResolveFallbackTransition(string fromStateId, string toStateId)
+        {
+            if (_stateGraph == null)
+            {
+                return null;
+            }
+
+            foreach (var edge in _stateGraph.transitions)
+            {
+                if (edge == null || edge.profile == null)
+                {
+                    continue;
+                }
+
+                bool fromMatches = string.Equals(edge.fromStateId, fromStateId, StringComparison.Ordinal);
+                if (!fromMatches)
+                {
+                    if (string.IsNullOrEmpty(fromStateId) && string.IsNullOrEmpty(edge.fromStateId))
+                    {
+                        fromMatches = true;
+                    }
+                    else if (string.Equals(edge.fromStateId, "*", StringComparison.Ordinal))
+                    {
+                        fromMatches = true;
+                    }
+                }
+
+                if (!fromMatches)
+                {
+                    continue;
+                }
+
+                if (string.Equals(edge.toStateId, toStateId, StringComparison.Ordinal))
+                {
+                    return edge.profile;
+                }
+            }
+
+            return null;
+        }
+        private List<ActorContext> BuildActorContexts(UIStateProfile fromProfile, UIStateProfile toProfile)
+        {
+            var list = new List<ActorContext>();
+            foreach (var kv in _actors)
+            {
+                var actor = kv.Value;
+                if (actor == null)
+                {
+                    continue;
+                }
+
+                UIStateProfile.RoleBinding fromBinding = null;
+                UIStateProfile.RoleBinding toBinding = null;
+                fromProfile?.TryGetBindingForActor(actor.ActorId, out fromBinding);
+                toProfile?.TryGetBindingForActor(actor.ActorId, out toBinding);
+
+                if (fromBinding == null && toBinding == null)
+                {
+                    continue;
+                }
+
+                list.Add(new ActorContext
+                {
+                    actor = actor,
+                    fromBinding = fromBinding,
+                    toBinding = toBinding
+                });
+            }
+
+            return list;
+        }
+
+        private List<ActorContext> FilterParticipants(List<ActorContext> contexts, UITransitionProfile.PhaseSettings phase)
+        {
+            var result = new List<ActorContext>();
+            foreach (var context in contexts)
+            {
+                bool participates = phase.role switch
+                {
+                    UITransitionProfile.PhaseRole.Exit => context.fromBinding != null,
+                    UITransitionProfile.PhaseRole.Enter => context.toBinding != null,
+                    UITransitionProfile.PhaseRole.Both => context.fromBinding != null || context.toBinding != null,
+                    _ => false
+                };
+
+                if (!participates)
+                {
+                    continue;
+                }
+
+                string tag = context.actor != null ? context.actor.ChoreoTag : null;
+                if (phase.includeTags != null && phase.includeTags.Count > 0)
+                {
+                    bool contains = false;
+                    for (int i = 0; i < phase.includeTags.Count; i++)
+                    {
+                        if (phase.includeTags[i] == tag)
+                        {
+                            contains = true;
+                            break;
+                        }
+                    }
+
+                    if (!contains)
+                    {
+                        if (!phase.includeUntagged || !string.IsNullOrEmpty(tag))
+                        {
+                            continue;
+                        }
+                    }
+                }
+                else if (!phase.includeUntagged && string.IsNullOrEmpty(tag))
+                {
+                    continue;
+                }
+
+                result.Add(context);
+            }
+
+            return result;
+        }
+
+        private void SortParticipants(List<ActorContext> participants, UITransitionProfile.PhaseSettings phase)
+        {
+            switch (phase.sortMode)
+            {
+                case UITransitionProfile.SortMode.ByTagOrder:
+                    participants.Sort((a, b) => CompareTagOrder(a.actor, b.actor, phase.tagOrder, phase.ascending));
+                    break;
+                case UITransitionProfile.SortMode.ByGrid:
+                    participants.Sort((a, b) => CompareGridIndex(a, b, phase));
+                    break;
+                case UITransitionProfile.SortMode.ByScreenX:
+                    participants.Sort((a, b) => CompareScreenPosition(a, b, phase, true));
+                    break;
+                case UITransitionProfile.SortMode.ByScreenY:
+                    participants.Sort((a, b) => CompareScreenPosition(a, b, phase, false));
+                    break;
+                case UITransitionProfile.SortMode.ByWeight:
+                    participants.Sort((a, b) => CompareWeight(a.actor, b.actor, phase.ascending));
+                    break;
+                case UITransitionProfile.SortMode.None:
+                default:
+                    break;
+            }
+        }
+
+        private List<float> ComputeOffsets(int count, UITransitionProfile.PhaseSettings phase)
+        {
+            if (count <= 0)
+            {
+                return null;
+            }
+
+            var stagger = phase.stagger ?? new UITransitionProfile.StaggerSettings();
+            var result = new List<float>(count);
+            switch (stagger.mode)
+            {
+                case UITransitionProfile.StaggerMode.None:
+                    for (int i = 0; i < count; i++) result.Add(0f);
+                    break;
+                case UITransitionProfile.StaggerMode.FixedInterval:
+                    float step = Mathf.Max(0f, stagger.interval);
+                    for (int i = 0; i < count; i++) result.Add(i * step);
+                    break;
+                case UITransitionProfile.StaggerMode.Grouped:
+                    int groupSize = Mathf.Max(1, stagger.groupSize);
+                    float interval = Mathf.Max(0f, stagger.groupInterval);
+                    for (int i = 0; i < count; i++)
+                    {
+                        int groupIndex = i / groupSize;
+                        result.Add(groupIndex * interval);
+                    }
+                    break;
+            }
+
+            return result;
+        }
+
+        private UIStateProfile.RoleBinding SelectBindingForPhase(ActorContext context, UITransitionProfile.PhaseRole role)
+        {
+            return role switch
+            {
+                UITransitionProfile.PhaseRole.Exit => context.fromBinding,
+                UITransitionProfile.PhaseRole.Enter => context.toBinding,
+                UITransitionProfile.PhaseRole.Both => context.toBinding ?? context.fromBinding,
+                _ => context.toBinding ?? context.fromBinding
+            };
+        }
+
+        private UIActorSchedule BuildActorSchedule(UITransitionPlan plan, UITransitionProfile.PhaseSettings phase, ActorContext context, UIStateProfile.RoleBinding binding, float phaseStartTime, float localOffset)
+        {
+            string presetKey = ResolvePresetKey(phase, context.actor, binding);
+            var schedule = new UIActorSchedule
+            {
+                transitionId = plan.transitionId,
+                actorId = context.actor.ActorId,
+                roleId = binding.roleId,
+                phaseName = phase.phaseName,
+                targetStateId = plan.toStateId,
+                anchorId = binding.anchorId,
+                styleVariant = binding.styleVariant,
+                presetKey = presetKey,
+                targetVisible = binding.visible,
+                useUnscaledTime = _useUnscaledTime,
+                dispatchTime = phaseStartTime,
+                localDelay = Mathf.Max(0f, localOffset),
+                durationHint = Mathf.Max(phase.minimumDuration, phase.tailHold),
+                isEnterPhase = phase.role != UITransitionProfile.PhaseRole.Exit,
+                isExitPhase = phase.role != UITransitionProfile.PhaseRole.Enter
+            };
+
+            if (!string.IsNullOrEmpty(binding.anchorId) && UIAnchorRegistry.TryGetSnapshot(binding.anchorId, out var snapshot))
+            {
+                schedule.hasSnapshot = true;
+                schedule.snapshot = snapshot;
+            }
+            else
+            {
+                schedule.hasSnapshot = false;
+            }
+
+            return schedule;
+        }
+
+        private string ResolvePresetKey(UITransitionProfile.PhaseSettings phase, UIActor actor, UIStateProfile.RoleBinding binding)
+        {
+            if (binding != null && binding.phasePresets != null)
+            {
+                for (int i = 0; i < binding.phasePresets.Count; i++)
+                {
+                    var preset = binding.phasePresets[i];
+                    if (preset != null && preset.phaseName == phase.phaseName && !string.IsNullOrEmpty(preset.presetKey))
+                    {
+                        return preset.presetKey;
+                    }
+                }
+            }
+
+            string actorPreset = actor != null ? actor.ResolvePreset(binding?.roleId, phase.phaseName) : null;
+            if (!string.IsNullOrEmpty(actorPreset))
+            {
+                return actorPreset;
+            }
+
+            return phase.defaultPresetKey;
+        }
+
+        private int CompareTagOrder(UIActor a, UIActor b, List<string> tagOrder, bool ascending)
+        {
+            int ia = IndexOf(tagOrder, a != null ? a.ChoreoTag : null);
+            int ib = IndexOf(tagOrder, b != null ? b.ChoreoTag : null);
+            int cmp = ia.CompareTo(ib);
+            if (cmp == 0)
+            {
+                cmp = CompareWeight(a, b, true);
+            }
+            return ascending ? cmp : -cmp;
+        }
+
+        private int CompareGridIndex(ActorContext a, ActorContext b, UITransitionProfile.PhaseSettings phase)
+        {
+            var bindingA = SelectBindingForPhase(a, phase.role);
+            var bindingB = SelectBindingForPhase(b, phase.role);
+            Vector2Int gridA = bindingA != null ? bindingA.gridIndex : Vector2Int.zero;
+            Vector2Int gridB = bindingB != null ? bindingB.gridIndex : Vector2Int.zero;
+
+            int rowCmp = phase.gridTopToBottom ? gridA.y.CompareTo(gridB.y) : gridB.y.CompareTo(gridA.y);
+            if (rowCmp != 0) return rowCmp;
+            int colCmp = phase.gridLeftToRight ? gridA.x.CompareTo(gridB.x) : gridB.x.CompareTo(gridA.x);
+            if (colCmp != 0) return colCmp;
+            return CompareWeight(a.actor, b.actor, true);
+        }
+
+        private int CompareScreenPosition(ActorContext a, ActorContext b, UITransitionProfile.PhaseSettings phase, bool byX)
+        {
+            Vector2 posA = GetAnchorScreenPosition(a, phase.role);
+            Vector2 posB = GetAnchorScreenPosition(b, phase.role);
+            int cmp = byX ? posA.x.CompareTo(posB.x) : posA.y.CompareTo(posB.y);
+            if (!phase.ascending) cmp = -cmp;
+            if (cmp == 0)
+            {
+                cmp = CompareWeight(a.actor, b.actor, true);
+            }
+            return cmp;
+        }
+
+        private Vector2 GetAnchorScreenPosition(ActorContext context, UITransitionProfile.PhaseRole role)
+        {
+            var binding = SelectBindingForPhase(context, role);
+            if (binding != null && !string.IsNullOrEmpty(binding.anchorId) && UIAnchorRegistry.TryGetAnchor(binding.anchorId, out var anchor) && anchor != null)
+            {
+                var rect = anchor.GetRectTransform();
+                if (rect != null)
+                {
+                    Vector3 world = rect.TransformPoint(rect.rect.center);
+                    return new Vector2(world.x, world.y);
+                }
+            }
+
+            var actorRect = context.actor != null ? context.actor.RectTransform : null;
+            if (actorRect != null)
+            {
+                Vector3 world = actorRect.TransformPoint(actorRect.rect.center);
+                return new Vector2(world.x, world.y);
+            }
+
+            return Vector2.zero;
+        }
+
+        private int CompareWeight(UIActor a, UIActor b, bool ascending)
+        {
+            float wa = a != null ? a.ChoreoWeight : 0f;
+            float wb = b != null ? b.ChoreoWeight : 0f;
+            int cmp = wa.CompareTo(wb);
+            return ascending ? cmp : -cmp;
+        }
+
+        private static int IndexOf(List<string> list, string value)
+        {
+            if (list == null || list.Count == 0)
+            {
+                return 0;
+            }
+
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (list[i] == value)
+                {
+                    return i;
+                }
+            }
+
+            return list.Count;
+        }
+
+        private class ActorContext
+        {
+            public UIActor actor;
+            public UIStateProfile.RoleBinding fromBinding;
+            public UIStateProfile.RoleBinding toBinding;
+        }
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIRoleAnchor.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIRoleAnchor.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// Lightweight marker component that marks a RectTransform as an anchor for a specific role/state binding.
+    /// Anchors can live anywhere in the hierarchy (hidden or visible) and are used to provide positional targets.
+    /// </summary>
+    [ExecuteAlways]
+    [DisallowMultipleComponent]
+    public sealed class UIRoleAnchor : MonoBehaviour
+    {
+        [SerializeField]
+        private string _anchorId;
+
+        [SerializeField]
+        private bool _autoRegister = true;
+
+        private RectTransform _rectTransform;
+
+        public string AnchorId => _anchorId;
+
+        private void OnEnable()
+        {
+            EnsureRectTransform();
+            if (_autoRegister)
+            {
+                UIAnchorRegistry.Register(this);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_autoRegister)
+            {
+                UIAnchorRegistry.Unregister(this);
+            }
+        }
+
+        private void Reset()
+        {
+            EnsureRectTransform();
+            if (string.IsNullOrEmpty(_anchorId) && _rectTransform != null)
+            {
+                _anchorId = gameObject.name;
+            }
+        }
+
+        private void EnsureRectTransform()
+        {
+            if (_rectTransform == null)
+            {
+                _rectTransform = GetComponent<RectTransform>();
+            }
+        }
+
+        public RectTransform GetRectTransform()
+        {
+            EnsureRectTransform();
+            return _rectTransform;
+        }
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIStateGraphAsset.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIStateGraphAsset.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// Defines the collection of available states and transition profiles.
+    /// </summary>
+    [CreateAssetMenu(menuName = "ITC/UI/Choreography/UI State Graph", fileName = "UIStateGraph")]
+    public class UIStateGraphAsset : ScriptableObject
+    {
+        public List<UIStateProfile> states = new List<UIStateProfile>();
+        public List<StateTransition> transitions = new List<StateTransition>();
+
+        [Serializable]
+        public class StateTransition
+        {
+            public string fromStateId;
+            public string toStateId;
+            public UITransitionProfile profile;
+        }
+
+        public bool TryGetState(string stateId, out UIStateProfile profile)
+        {
+            for (int i = 0; i < states.Count; i++)
+            {
+                var candidate = states[i];
+                if (candidate != null && candidate.stateId == stateId)
+                {
+                    profile = candidate;
+                    return true;
+                }
+            }
+
+            profile = null;
+            return false;
+        }
+
+        public bool TryGetTransition(string fromStateId, string toStateId, out UITransitionProfile profile)
+        {
+            for (int i = 0; i < transitions.Count; i++)
+            {
+                var edge = transitions[i];
+                if (edge != null && edge.fromStateId == fromStateId && edge.toStateId == toStateId)
+                {
+                    profile = edge.profile;
+                    return profile != null;
+                }
+            }
+
+            profile = null;
+            return false;
+        }
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIStateMachine.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIStateMachine.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// Thin convenience wrapper that forwards transition requests to the global orchestrator.
+    /// </summary>
+    public class UIStateMachine : MonoBehaviour
+    {
+        [SerializeField]
+        private UIOrchestrator _orchestrator;
+
+        private void Awake()
+        {
+            if (_orchestrator == null)
+            {
+                _orchestrator = GetComponentInChildren<UIOrchestrator>();
+            }
+        }
+
+        public void RequestState(string stateId)
+        {
+            if (_orchestrator == null)
+            {
+                _orchestrator = UIOrchestrator.Instance;
+            }
+
+            if (_orchestrator != null)
+            {
+                _orchestrator.RequestTransition(stateId);
+            }
+            else
+            {
+                Debug.LogWarning("[UIStateMachine] No UIOrchestrator available to handle RequestState.", this);
+            }
+        }
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIStateProfile.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UIStateProfile.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// ScriptableObject describing how actors bind to roles inside a UI state.
+    /// </summary>
+    [CreateAssetMenu(menuName = "ITC/UI/Choreography/UI State Profile", fileName = "UIStateProfile")]
+    public class UIStateProfile : ScriptableObject
+    {
+        public string stateId;
+        public List<RoleBinding> roleBindings = new List<RoleBinding>();
+        public List<string> defaultPhaseOrder = new List<string>();
+
+        [Serializable]
+        public class RoleBinding
+        {
+            [Tooltip("Logical actor identifier that should occupy this role when the state becomes active.")]
+            public string actorId;
+
+            [Tooltip("Role identifier (e.g. PauseItem, HeaderShortcut).")]
+            public string roleId;
+
+            [Tooltip("Anchor identifier resolved at runtime via UIRoleAnchor.")]
+            public string anchorId;
+
+            [Tooltip("Optional style variant keyword passed to UIActor style handlers.")]
+            public string styleVariant;
+
+            [Tooltip("Whether the actor should be visible when the state is active.")]
+            public bool visible = true;
+
+            [Tooltip("Optional grid coordinate for ByGrid ordering (row, column).")]
+            public Vector2Int gridIndex = Vector2Int.zero;
+
+            [Tooltip("Optional overrides for presets per phase.")]
+            public List<RolePhasePreset> phasePresets = new List<RolePhasePreset>();
+        }
+
+        [Serializable]
+        public class RolePhasePreset
+        {
+            public string phaseName;
+            public string presetKey;
+        }
+
+        public bool TryGetBindingForActor(string actorId, out RoleBinding binding)
+        {
+            for (int i = 0; i < roleBindings.Count; i++)
+            {
+                var candidate = roleBindings[i];
+                if (candidate != null && candidate.actorId == actorId)
+                {
+                    binding = candidate;
+                    return true;
+                }
+            }
+
+            binding = null;
+            return false;
+        }
+
+        public RoleBinding TryGetBindingForRole(string roleId)
+        {
+            for (int i = 0; i < roleBindings.Count; i++)
+            {
+                var candidate = roleBindings[i];
+                if (candidate != null && candidate.roleId == roleId)
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
+        }
+
+        public IEnumerable<RoleBinding> GetBindings()
+        {
+            return roleBindings;
+        }
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UITransitionEvents.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UITransitionEvents.cs
@@ -1,0 +1,105 @@
+using System;
+using UnityEngine;
+
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// Represents a high-level request to transition from one UI state to another.
+    /// </summary>
+    [Serializable]
+    public class UITransitionCommand
+    {
+        public string fromStateId;
+        public string toStateId;
+        public string reason;
+        public object payload;
+
+        public UITransitionCommand(string from, string to, string reason = null, object payload = null)
+        {
+            fromStateId = from;
+            toStateId = to;
+            this.reason = reason;
+            this.payload = payload;
+        }
+    }
+
+    public enum UITransitionLifecycle
+    {
+        Requested,
+        Planned,
+        Started,
+        Completed,
+        Cancelled
+    }
+
+    [Serializable]
+    public class UITransitionLifecycleEvent
+    {
+        public string transitionId;
+        public string fromStateId;
+        public string toStateId;
+        public UITransitionLifecycle lifecycle;
+        public UITransitionProfile profile;
+
+        public UITransitionLifecycleEvent(string id, string from, string to, UITransitionLifecycle phase, UITransitionProfile profile)
+        {
+            transitionId = id;
+            fromStateId = from;
+            toStateId = to;
+            lifecycle = phase;
+            this.profile = profile;
+        }
+    }
+
+    public enum UIPhaseEventType
+    {
+        PhaseStarted,
+        PhaseCompleted
+    }
+
+    [Serializable]
+    public class UIPhaseEvent
+    {
+        public string transitionId;
+        public string phaseName;
+        public UIPhaseEventType eventType;
+        public float scheduledTime;
+        public float duration;
+
+        public UIPhaseEvent(string transitionId, string phaseName, UIPhaseEventType eventType, float scheduledTime, float duration)
+        {
+            this.transitionId = transitionId;
+            this.phaseName = phaseName;
+            this.eventType = eventType;
+            this.scheduledTime = scheduledTime;
+            this.duration = duration;
+        }
+    }
+
+    /// <summary>
+    /// Runtime schedule for a single actor inside a transition phase.
+    /// </summary>
+    [Serializable]
+    public struct UIActorSchedule
+    {
+        public string transitionId;
+        public string actorId;
+        public string roleId;
+        public string phaseName;
+        public string targetStateId;
+        public string anchorId;
+        public string styleVariant;
+        public string presetKey;
+        public bool targetVisible;
+        public bool useUnscaledTime;
+        public bool hasSnapshot;
+        public RectTransformSnapshot snapshot;
+        public float dispatchTime;
+        public float localDelay;
+        public float durationHint;
+        public bool isEnterPhase;
+        public bool isExitPhase;
+
+        public float GetScheduledTime() => dispatchTime + localDelay;
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UITransitionPlan.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UITransitionPlan.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// Runtime data structure describing a resolved transition between two states.
+    /// </summary>
+    public class UITransitionPlan
+    {
+        public readonly string transitionId;
+        public readonly string fromStateId;
+        public readonly string toStateId;
+        public readonly UITransitionProfile profile;
+        public readonly List<UIPhaseSchedule> phases = new List<UIPhaseSchedule>();
+
+        public UITransitionPlan(string transitionId, string fromStateId, string toStateId, UITransitionProfile profile)
+        {
+            this.transitionId = transitionId;
+            this.fromStateId = fromStateId;
+            this.toStateId = toStateId;
+            this.profile = profile;
+        }
+    }
+
+    /// <summary>
+    /// Schedule for a single phase (with timing + participating actors).
+    /// </summary>
+    public class UIPhaseSchedule
+    {
+        public string phaseName;
+        public float startTime;
+        public float duration;
+        public readonly List<UIActorSchedule> actorSchedules = new List<UIActorSchedule>();
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UITransitionProfile.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UITransitionProfile.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// ScriptableObject describing choreography rules for a transition between two UI states.
+    /// </summary>
+    [CreateAssetMenu(menuName = "ITC/UI/Choreography/UI Transition Profile", fileName = "UITransitionProfile")]
+    public class UITransitionProfile : ScriptableObject
+    {
+        public string fromStateId;
+        public string toStateId;
+        public ConflictPolicy conflictPolicy = ConflictPolicy.Interrupt;
+        public FallbackBehavior fallbackBehavior = FallbackBehavior.Hide;
+        public List<PhaseSettings> phases = new List<PhaseSettings>
+        {
+            new PhaseSettings { phaseName = "PreExit", role = PhaseRole.Exit },
+            new PhaseSettings { phaseName = "Exit", role = PhaseRole.Exit },
+            new PhaseSettings { phaseName = "Enter", role = PhaseRole.Enter },
+            new PhaseSettings { phaseName = "PostEnter", role = PhaseRole.Enter }
+        };
+
+        public enum ConflictPolicy
+        {
+            Interrupt,
+            Blend,
+            Queue
+        }
+
+        public enum FallbackBehavior
+        {
+            Hide,
+            DisableInteractions,
+            KeepLastState
+        }
+
+        public enum PhaseRole
+        {
+            Exit,
+            Enter,
+            Both
+        }
+
+        public enum SortMode
+        {
+            None,
+            ByTagOrder,
+            ByGrid,
+            ByScreenX,
+            ByScreenY,
+            ByWeight
+        }
+
+        public enum StaggerMode
+        {
+            None,
+            FixedInterval,
+            Grouped
+        }
+
+        [Serializable]
+        public class PhaseSettings
+        {
+            [Tooltip("Name of the phase (used for events and preset lookup).")]
+            public string phaseName = "Enter";
+
+            [Tooltip("Whether this phase targets exiting actors, entering actors, or both.")]
+            public PhaseRole role = PhaseRole.Enter;
+
+            [Tooltip("Tags that should participate. Empty = all.")]
+            public List<string> includeTags = new List<string>();
+
+            [Tooltip("Include actors that have no choreo tag assigned.")]
+            public bool includeUntagged = true;
+
+            [Tooltip("Delay before the phase starts relative to the previous phase ending.")]
+            public float preDelay = 0f;
+
+            [Tooltip("Minimum duration (used to compute when the next phase may start).")]
+            public float minimumDuration = 0.2f;
+
+            [Tooltip("Additional time added after the last staggered actor.")]
+            public float tailHold = 0.05f;
+
+            [Tooltip("Sort ordering for participating actors.")]
+            public SortMode sortMode = SortMode.ByTagOrder;
+
+            [Tooltip("Tag order priority used when SortMode=ByTagOrder.")]
+            public List<string> tagOrder = new List<string> { "Header", "Primary", "Secondary", "ListItem", "Footer" };
+
+            [Tooltip("When SortMode=ByGrid this controls row priority (true=top to bottom).")]
+            public bool gridTopToBottom = true;
+
+            [Tooltip("When SortMode=ByGrid this controls column priority (true=left to right).")]
+            public bool gridLeftToRight = true;
+
+            [Tooltip("When SortMode=ByScreenX/Y, true=ascending, false=descending.")]
+            public bool ascending = true;
+
+            [Tooltip("Stagger settings for actor activation within the phase.")]
+            public StaggerSettings stagger = new StaggerSettings();
+
+            [Tooltip("Optional preset override that applies to all actors in this phase when specific mapping is missing.")]
+            public string defaultPresetKey;
+        }
+
+        [Serializable]
+        public class StaggerSettings
+        {
+            public StaggerMode mode = StaggerMode.FixedInterval;
+            public float interval = 0.03f;
+            public int groupSize = 3;
+            public float groupInterval = 0.1f;
+        }
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UITweenActorGoalApplier.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/UITweenActorGoalApplier.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+
+namespace ITC.UI.Choreography
+{
+    /// <summary>
+    /// Simple goal applier that bridges UIActor schedules to the existing UITweenPlayer component.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(UIActor))]
+    public class UITweenActorGoalApplier : MonoBehaviour, IUIActorGoalApplier
+    {
+        [SerializeField]
+        private UITweenPlayer _tweenPlayer;
+
+        [SerializeField]
+        private bool _applySnapshotBeforePlay = true;
+
+        private UIActor _actor;
+
+        private void Awake()
+        {
+            _actor = GetComponent<UIActor>();
+            if (_tweenPlayer == null)
+            {
+                _tweenPlayer = GetComponent<UITweenPlayer>();
+            }
+        }
+
+        public void Apply(UIActor actor, UIActorSchedule schedule)
+        {
+            if (_applySnapshotBeforePlay && schedule.hasSnapshot)
+            {
+                schedule.snapshot.ApplyTo(actor.RectTransform);
+            }
+
+            if (_tweenPlayer == null)
+            {
+                return;
+            }
+
+            string presetKey = schedule.presetKey;
+            if (string.IsNullOrEmpty(presetKey))
+            {
+                presetKey = actor.ResolvePreset(schedule.roleId, schedule.phaseName);
+            }
+
+            if (!string.IsNullOrEmpty(presetKey))
+            {
+                _tweenPlayer.PlayByName(presetKey);
+            }
+        }
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/使用指南.md
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/UI动画编排系统/使用指南.md
@@ -1,0 +1,106 @@
+# UI 编舞系统使用指南
+
+本文档说明如何在 Unity 项目中使用新增的 **UI 状态图 + 角色 + 编舞标签** 方案。系统划分为 **数据层（ScriptableObject）**、**运行时服务（Orchestrator + Conductor）**、**自治组件（Actor）** 三部分，并通过事件总线实现去耦合调度。
+
+## 核心脚本一览
+
+| 文件 | 作用 |
+| --- | --- |
+| `UIStateGraphAsset` | 统一管理状态、过渡与配置的 ScriptableObject。 |
+| `UIStateProfile` | 描述一个 UI State 内的角色绑定（Actor → Role → Anchor/样式）。 |
+| `UITransitionProfile` | 描述 State 间的过渡规则（Phase、排序、错峰、冲突策略等）。 |
+| `UIOrchestrator` | 状态机调度中心：解析过渡请求 → 生成 `UITransitionPlan`。 |
+| `UIConductor` | 按时间发布 Phase/Actor 调度事件。 |
+| `UIEventBus` + `UITransitionEvents` | 事件总线，承载 `TransitionCommand`、`PhaseEvent`、`UIActorSchedule` 等。 |
+| `UIActor` | 绑定在按钮/控件上的自治组件，订阅调度事件并驱动本地 Tween。 |
+| `UITweenActorGoalApplier` | 桥接 `UIActor` 与现有 `UITweenPlayer`，自动播放录制好的预设。 |
+| `UIRoleAnchor` + `UIAnchorRegistry` | 在场景中标记锚点、暴露快照。 |
+| `RectTransformSnapshot` | 锚点几何状态的快照结构。 |
+| `IUIActorGoalApplier` / `IUIActorStyleHandler` | 扩展接口，可自定义目标驱动与样式切换。 |
+| `UIStateMachine` | 旧入口的轻量兼容封装，直接把请求转发给 Orchestrator。 |
+
+## 搭建步骤
+
+### 1. 准备锚点（Anchor）
+1. 在 UI 层级中创建空物体或辅助节点，挂载 `UIRoleAnchor`。
+2. 为每个锚点设置唯一的 `AnchorId`，可与角色语义一致（例如 `Pause/Menu/PlaySlot`）。
+3. 运行时 `UIRoleAnchor` 会自动向 `UIAnchorRegistry` 注册，Orchestrator/Actor 可按需读取其 `RectTransformSnapshot`。
+
+> 锚点可以放在不可见节点上，仅用作目标姿态数据，与 "目标驱动 + 录制" 系统完全兼容。
+
+### 2. 建立状态与角色绑定
+1. 在 Project 窗口创建 `UIStateProfile` 资产。
+2. `stateId`：填写状态唯一标识（如 `Main`, `Pause`, `Settings`）。
+3. `roleBindings`：为每个参与的 Actor 添加一条记录：
+   - `actorId`：与 `UIActor` 组件中的 `ActorId` 对应。
+   - `roleId`：描述角色语义（如 `PauseItem`, `HeaderShortcut`）。
+   - `anchorId`：引用到上一步的锚点。
+   - `styleVariant`：可选的样式关键字，会广播给 `IUIActorStyleHandler`。
+   - `visible`：进入该状态后是否应显示。
+   - `gridIndex`：用于 `ByGrid` 排序的行列信息。
+   - `phasePresets`：可选，为特定 Phase 指定局部预设名（覆盖 Actor 默认设置）。
+
+### 3. 配置状态图与过渡
+1. 创建 `UIStateGraphAsset`，将所有 `UIStateProfile` 加入 `states` 列表。
+2. 为每条过渡添加 `StateTransition`：
+   - `fromStateId`/`toStateId`：匹配状态；支持使用 `*` 或空字符串表示通配。
+   - `profile`：关联一个 `UITransitionProfile`。
+3. 在 `UITransitionProfile` 中定义编舞策略：
+   - `conflictPolicy`：新请求到来时是打断（Interrupt）、融合（Blend）还是排队（Queue）。
+   - `fallbackBehavior`：目标状态缺少绑定时的默认动作。
+   - `phases`：配置 Phase 顺序、参与标签、排序/错峰、默认预设。典型序列：`PreExit → Exit → Enter → PostEnter`。
+     * `includeTags` / `includeUntagged` 用于筛选 Actor。
+     * `sortMode` 支持 `ByTagOrder`、`ByGrid`、`ByScreenX/Y`、`ByWeight` 等。
+     * `stagger` 提供固定间隔或分组错峰，适配 60–80 个按钮的批次调度。
+     * `defaultPresetKey`：当角色/Actor未提供专用预设时的兜底键名。
+
+### 4. 场景中放置运行时服务
+1. 创建空物体，例如 `UI Orchestrator Root`，挂载 `UIOrchestrator` 与 `UIConductor`。
+2. 在 Orchestrator 上：
+   - 绑定 `UIStateGraphAsset`。
+   - 指定 `Initial State Id`（可选）。
+   - 如果有 `UIConductor` 子物体，序列化引用或自动查找。
+3. `UIConductor` 可选择使用缩放或非缩放时间（`_useUnscaledClock`）。
+4. 可保留 `UIStateMachine` 作为旧逻辑入口，只需把请求转发到 Orchestrator。
+
+### 5. 配置 Actor（按钮/控件）
+1. 在目标 UI 元素上挂载 `UIActor`：
+   - `ActorId`：全局唯一，需与 `UIStateProfile` 中一致。
+   - `Choreo Tag`：如 `Header`, `Primary`, `Secondary`, `ListItem`, `Footer`，用于 Phase 内排序/分组。
+   - `Choreo Weight`：当排序模式为 `ByWeight` 或同优先级时的细粒度顺序控制。
+   - `Role Presets`：为不同角色配置默认入场/退场及 Phase 覆盖的预设键。
+   - `Fallback Enter/Exit Preset`：未命中更具体配置时使用。
+   - `Visibility` 设置可自动启用/关闭 `CanvasGroup` 交互，以及在退场 Phase 结束后禁用 GameObject。
+2. 根据需要添加实现了 `IUIActorGoalApplier` 的组件：
+   - 默认提供的 `UITweenActorGoalApplier` 会：
+     * 把锚点 `RectTransformSnapshot` 应用为目标姿态；
+     * 调用现有的 `UITweenPlayer.PlayByName(presetKey)` 播放录制好的 DOTween 预设。
+3. 如需根据 `styleVariant` 切换皮肤，可实现 `IUIActorStyleHandler`（例如驱动材质、Sprite 或可视化状态机）。
+
+### 6. 发起过渡
+- 代码或 Timeline 中调用：
+  ```csharp
+  UIOrchestrator.Instance.RequestTransition("Settings");
+  // 或发送事件：
+  UIEventBus.Publish(new UITransitionCommand(currentState, "Pause", "UserPressedPause"));
+  ```
+- Actor 层完全通过事件驱动，彼此之间没有直接引用，便于维护与扩展。
+
+## 调试技巧
+- 在编辑器中给 `UIOrchestrator` 或 `UIConductor` 添加自定义 Inspector，可可视化当前计划（本指南未包含）。
+- 观察 `UIEventBus` 事件：
+  - `TransitionLifecycleChanged`：过渡生命周期。
+  - `PhaseEventRaised`：Phase 开始/结束。
+  - `ActorScheduled`：单个 Actor 的调度细节（phase、role、preset、延迟等）。
+- 若某个 Actor 未响应：
+  1. 检查 `ActorId` 是否匹配。
+  2. 确认目标状态的 `UIStateProfile` 是否包含相应角色绑定。
+  3. 确保 Phase 的 `includeTags` 覆盖该 Actor 的 `ChoreoTag`，或允许 `includeUntagged`。
+  4. 核对 `UIRoleAnchor` 是否成功注册（GameObject 激活、ID 唯一）。
+
+## 扩展建议
+- 若需要更复杂的冲突策略，可在 `UIConductor.CancelCurrentPlan` 中扩展：例如 Blend/Queue 逻辑。
+- `UITransitionProfile` 支持在 Phase 中设置自定义排序器，亦可扩展 `SortMode` 枚举并在 `UIOrchestrator.SortParticipants` 中实现。
+- 对于 “大表单 + 列表” 等场景，可利用 `gridIndex`、`ByScreenY` 与 `Grouped` 错峰组合，确保 80 个按钮也能顺序平稳。
+
+按照以上步骤即可完成从 “面板时间线” 到 “状态图 + 角色 + 标签编舞” 的迁移，实现跨面板编舞与组件自治并存的工作流。


### PR DESCRIPTION
## Summary
- add ScriptableObject profiles and state graph assets for the UI choreography pipeline
- implement orchestration runtime (event bus, conductor, orchestrator, actor & tween bridge)
- document setup and configuration workflow for the new system

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68f07e06e9f8832999a38e2baf0c72b1