### PR TITLE
Add secondary UI tween tracks and timeline editor visualization

### DIFF
--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenControllerEditor.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenControllerEditor.cs
@@ -1,7 +1,10 @@
 #if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using DG.Tweening;
 using UnityEditor;
 using UnityEngine;
-using DG.Tweening;
+using UnityEngine.UI;
 
 [CustomEditor(typeof(UITweenController))]
 public class UITweenControllerEditor : Editor
@@ -19,6 +22,7 @@ public class UITweenControllerEditor : Editor
     Snap _snap;
     bool _hasSnap = false; // 核心状态标志：是否已经捕获快照并进入预览模式
     Tween _previewTween;
+    readonly List<Action> _restoreActions = new List<Action>();
 
     void OnEnable()
     {
@@ -192,11 +196,28 @@ public class UITweenControllerEditor : Editor
 
         EditorGUILayout.Space();
         EditorGUILayout.PropertyField(serializedObject.FindProperty("showPathGizmos"));
-        
+
+        EditorGUILayout.Space();
+        using (new EditorGUILayout.VerticalScope("box"))
+        {
+            EditorGUILayout.LabelField("Secondary Animations", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("secondaryTweens"), true);
+        }
+
+        EditorGUILayout.Space();
+        using (new EditorGUILayout.VerticalScope("box"))
+        {
+            EditorGUILayout.LabelField("Timeline Events", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("timelineEvents"), true);
+        }
+
         // ==============================================================================
         // ==================== 核心修改区域 (Core Modification Area) ====================
         // ==============================================================================
-        
+
+        EditorGUILayout.Space();
+        DrawTimelineEditor();
+
         EditorGUILayout.Space();
         using (new EditorGUILayout.VerticalScope("box"))
         {
@@ -224,11 +245,216 @@ public class UITweenControllerEditor : Editor
 
         serializedObject.ApplyModifiedProperties();
     }
-    
+
+    private void DrawTimelineEditor()
+    {
+        EditorGUILayout.Space();
+        using (new EditorGUILayout.VerticalScope("box"))
+        {
+            EditorGUILayout.LabelField("Visual Timeline Editor", EditorStyles.boldLabel);
+
+            float totalDuration = Mathf.Max(0f, C.duration);
+            if (totalDuration <= 0f)
+            {
+                EditorGUILayout.HelpBox("Duration must be greater than 0 to display the timeline.", MessageType.Info);
+                return;
+            }
+
+            Rect timelineRect = EditorGUILayout.GetControlRect(false, 160f);
+            EditorGUI.DrawRect(timelineRect, new Color(0.12f, 0.12f, 0.12f));
+
+            Handles.BeginGUI();
+            DrawTimelineGrid(timelineRect, totalDuration);
+
+            int curveIndex = 0;
+            if (C.animatePosition)
+            {
+                DrawPropertyCurve(timelineRect, totalDuration, "Position", Color.cyan, curveIndex++, GetValueAtTime);
+            }
+            if (C.animateSize)
+            {
+                DrawPropertyCurve(timelineRect, totalDuration, "Size", Color.yellow, curveIndex++, GetValueAtTime);
+            }
+            if (C.animateRotationZ)
+            {
+                DrawPropertyCurve(timelineRect, totalDuration, "Rotation", Color.magenta, curveIndex++, GetValueAtTime);
+            }
+            if (C.animateAlpha)
+            {
+                DrawPropertyCurve(timelineRect, totalDuration, "Alpha", Color.green, curveIndex++, GetValueAtTime);
+            }
+            if (C.animateColor)
+            {
+                DrawPropertyCurve(timelineRect, totalDuration, "Color", Color.white, curveIndex++, GetValueAtTime);
+            }
+
+            var secondaryProp = serializedObject.FindProperty("secondaryTweens");
+            if (secondaryProp != null && secondaryProp.isArray)
+            {
+                for (int i = 0; i < secondaryProp.arraySize; i++)
+                {
+                    Color curveColor = Color.HSVToRGB(Mathf.Repeat(i * 0.2f, 1f), 0.8f, 1f);
+                    DrawSecondaryCurve(timelineRect, totalDuration, secondaryProp.GetArrayElementAtIndex(i), curveColor);
+                }
+                DrawSecondaryMarkers(timelineRect, totalDuration, secondaryProp, new Color(1f, 0.8f, 0f, 0.9f));
+            }
+
+            var eventProp = serializedObject.FindProperty("timelineEvents");
+            DrawTimelineEventMarkers(timelineRect, totalDuration, eventProp, new Color(0.2f, 1f, 0.4f, 0.9f));
+
+            Handles.EndGUI();
+        }
+    }
+
+    private void DrawTimelineGrid(Rect rect, float duration)
+    {
+        Handles.color = new Color(1f, 1f, 1f, 0.1f);
+        Handles.DrawSolidRectangleWithOutline(rect, new Color(1f, 1f, 1f, 0.05f), new Color(1f, 1f, 1f, 0.15f));
+
+        int gridLines = 10;
+        for (int i = 0; i <= gridLines; i++)
+        {
+            float normalized = i / (float)gridLines;
+            float x = Mathf.Lerp(rect.x, rect.xMax, normalized);
+            Handles.color = new Color(1f, 1f, 1f, 0.08f);
+            Handles.DrawLine(new Vector3(x, rect.y), new Vector3(x, rect.yMax));
+
+            GUI.Label(new Rect(x - 20f, rect.y - 18f, 50f, 16f), (duration * normalized).ToString("F2"), EditorStyles.whiteMiniLabel);
+        }
+        Handles.color = Color.white;
+    }
+
+    private void DrawPropertyCurve(Rect rect, float duration, string label, Color color, int index, Func<float, float> evaluate)
+    {
+        const int steps = 60;
+        Vector3[] points = new Vector3[steps + 1];
+        for (int i = 0; i <= steps; i++)
+        {
+            float normalizedTime = i / (float)steps;
+            float value = Mathf.Clamp01(evaluate(normalizedTime));
+            float x = Mathf.Lerp(rect.x, rect.xMax, normalizedTime);
+            float y = Mathf.Lerp(rect.yMax - 8f, rect.y + 24f, value);
+            points[i] = new Vector3(x, y);
+        }
+
+        Handles.color = color;
+        Handles.DrawAAPolyLine(2f, points);
+
+        var originalColor = GUI.color;
+        GUI.color = color;
+        GUI.Label(new Rect(rect.x + 6f, rect.y + 6f + index * 16f, 120f, 16f), label, EditorStyles.whiteMiniLabel);
+        GUI.color = originalColor;
+    }
+
+    private void DrawSecondaryCurve(Rect rect, float totalDuration, SerializedProperty secondaryTweenProp, Color color)
+    {
+        if (secondaryTweenProp == null) return;
+
+        float startTime = Mathf.Max(0f, secondaryTweenProp.FindPropertyRelative("startTime")?.floatValue ?? 0f);
+        float duration = Mathf.Max(0f, secondaryTweenProp.FindPropertyRelative("duration")?.floatValue ?? 0f);
+        if (duration <= 0f) return;
+
+        Ease easeType = (Ease)(secondaryTweenProp.FindPropertyRelative("easeType")?.enumValueIndex ?? (int)Ease.Linear);
+        string name = secondaryTweenProp.FindPropertyRelative("name")?.stringValue ?? "Secondary";
+
+        const int steps = 50;
+        Vector3[] points = new Vector3[steps + 1];
+        float minValue = 0f;
+        float maxValue = 1f;
+
+        for (int i = 0; i <= steps; i++)
+        {
+            float normalizedTime = i / (float)steps;
+            float easedValue = DOVirtual.EasedValue(0f, 1f, normalizedTime, easeType);
+            if (easedValue < minValue) minValue = easedValue;
+            if (easedValue > maxValue) maxValue = easedValue;
+        }
+
+        float valueRange = Mathf.Max(0.0001f, maxValue - minValue);
+
+        for (int i = 0; i <= steps; i++)
+        {
+            float normalizedTime = i / (float)steps;
+            float easedValue = DOVirtual.EasedValue(0f, 1f, normalizedTime, easeType);
+            float yValueNormalized = (easedValue - minValue) / valueRange;
+
+            float absoluteTime = startTime + duration * normalizedTime;
+            float x = TimeToPixel(rect, totalDuration, absoluteTime);
+            float y = Mathf.Lerp(rect.yMax - 8f, rect.y + 24f, yValueNormalized);
+            points[i] = new Vector3(x, y);
+        }
+
+        Handles.color = color;
+        Handles.DrawAAPolyLine(2f, points);
+
+        var originalColor = GUI.color;
+        GUI.color = color;
+        GUI.Label(new Rect(points[0].x + 5f, points[0].y - 15f, 160f, 16f), name, EditorStyles.whiteMiniLabel);
+        GUI.color = originalColor;
+        Handles.color = Color.white;
+    }
+
+    private void DrawSecondaryMarkers(Rect rect, float duration, SerializedProperty listProp, Color color)
+    {
+        if (listProp == null || !listProp.isArray) return;
+
+        for (int i = 0; i < listProp.arraySize; i++)
+        {
+            var element = listProp.GetArrayElementAtIndex(i);
+            float start = Mathf.Max(0f, element.FindPropertyRelative("startTime")?.floatValue ?? 0f);
+            float span = Mathf.Max(0f, element.FindPropertyRelative("duration")?.floatValue ?? 0f);
+
+            float xStart = TimeToPixel(rect, duration, start);
+            float xEnd = TimeToPixel(rect, duration, start + span);
+            float width = Mathf.Max(2f, xEnd - xStart);
+
+            float laneOffset = (i % 3) * 14f;
+            Rect markerRect = new Rect(xStart, rect.yMax - 24f - laneOffset, width, 10f);
+            Handles.DrawSolidRectangleWithOutline(markerRect, new Color(color.r, color.g, color.b, 0.35f), color);
+
+            GUI.Label(new Rect(markerRect.x, markerRect.y - 14f, 180f, 14f), element.FindPropertyRelative("name")?.stringValue ?? "Secondary", EditorStyles.whiteMiniLabel);
+        }
+        Handles.color = Color.white;
+    }
+
+    private void DrawTimelineEventMarkers(Rect rect, float duration, SerializedProperty listProp, Color color)
+    {
+        if (listProp == null || !listProp.isArray) return;
+
+        Handles.color = color;
+        for (int i = 0; i < listProp.arraySize; i++)
+        {
+            var element = listProp.GetArrayElementAtIndex(i);
+            float fireTime = Mathf.Max(0f, element.FindPropertyRelative("fireTime")?.floatValue ?? 0f);
+            float x = TimeToPixel(rect, duration, fireTime);
+            Handles.DrawLine(new Vector3(x, rect.y), new Vector3(x, rect.yMax));
+
+            GUI.Label(new Rect(x + 4f, rect.y + 6f + (i % 3) * 16f, 180f, 16f), element.FindPropertyRelative("name")?.stringValue ?? "Event", EditorStyles.whiteMiniLabel);
+        }
+        Handles.color = Color.white;
+    }
+
+    private float GetValueAtTime(float normalizedTime)
+    {
+        normalizedTime = Mathf.Clamp01(normalizedTime);
+        if (C.useCustomCurve && C.customCurve != null)
+        {
+            return Mathf.Clamp01(C.customCurve.Evaluate(normalizedTime));
+        }
+        return Mathf.Clamp01(DOVirtual.EasedValue(0f, 1f, normalizedTime, C.easeType));
+    }
+
+    private float TimeToPixel(Rect rect, float duration, float time)
+    {
+        if (duration <= 0f) return rect.x;
+        float normalized = Mathf.Clamp01(time / duration);
+        return Mathf.Lerp(rect.x, rect.xMax, normalized);
+    }
+
     void SafePlayPreview()
     {
         // 播放前先确保停止了任何旧的预览，这是一个好习惯
-        SafeStopPreview(); 
+        SafeStopPreview();
         
         var rt = C.GetComponent<RectTransform>();
         if (rt == null) return;
@@ -240,6 +466,52 @@ public class UITweenControllerEditor : Editor
         _snap.alpha = cg ? cg.alpha : (g ? g.color.a : 1f);
         _snap.color = g ? g.color : Color.white;
         _hasSnap = true;
+
+        _restoreActions.Clear();
+
+        if (C.timelineEvents != null)
+        {
+            foreach (var timelineEvent in C.timelineEvents)
+            {
+                if (timelineEvent == null) continue;
+                if (timelineEvent.eventType == TimelineEventType.ChangeSprite && timelineEvent.targetImage != null)
+                {
+                    var targetImage = timelineEvent.targetImage;
+                    var originalSprite = targetImage.sprite;
+                    _restoreActions.Add(() =>
+                    {
+                        if (targetImage != null)
+                        {
+                            Undo.RecordObject(targetImage, "Restore Timeline Sprite");
+                            targetImage.sprite = originalSprite;
+                        }
+                    });
+                }
+            }
+        }
+
+        bool scaleHandled = C.animateSize;
+        if (C.secondaryTweens != null)
+        {
+            foreach (var secTween in C.secondaryTweens)
+            {
+                if (secTween == null) continue;
+                if (secTween.propertyType == SecondaryTweenType.Scale && !scaleHandled)
+                {
+                    Vector3 originalScale = rt.localScale;
+                    var targetTransform = rt;
+                    _restoreActions.Add(() =>
+                    {
+                        if (targetTransform != null)
+                        {
+                            Undo.RecordObject(targetTransform, "Restore Secondary Scale");
+                            targetTransform.localScale = originalScale;
+                        }
+                    });
+                    scaleHandled = true;
+                }
+            }
+        }
 
         // 【修改点 2】: 移除了 .OnComplete(SafeStopPreview)
         // 这样动画播放一次后就会自然停止在目标状态，而不会自动回调恢复方法
@@ -275,6 +547,15 @@ public class UITweenControllerEditor : Editor
         
         var g = C.GetComponent<UnityEngine.UI.Graphic>();
         if (g != null) { Undo.RecordObject(g, "Restore Snapshot"); g.color = _snap.color; }
+
+        if (_restoreActions.Count > 0)
+        {
+            foreach (var action in _restoreActions)
+            {
+                action?.Invoke();
+            }
+            _restoreActions.Clear();
+        }
 
         // 重置状态标志，为下一次预览做准备
         // inEditorDisable 是为了防止组件在禁用时重置标志，导致状态丢失

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenController.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenController.cs
@@ -2,9 +2,11 @@
 // Jin Tang – Goal-Driven UI Tween (Bézier via pass-through point)
 // + Preset binding & autosave
 
-using UnityEngine;
-using UnityEngine.UI;
+using System.Collections.Generic;
 using DG.Tweening;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.UI;
 
 [DisallowMultipleComponent]
 [RequireComponent(typeof(RectTransform))]
@@ -50,6 +52,14 @@ public class UITweenController : MonoBehaviour
     public bool animateRotationZ = false;
     public bool animateAlpha = false;
     public bool animateColor = false;
+
+    [Header("Secondary Animations")]
+    [Tooltip("在主动画播放期间叠加的次级动画轨道")]
+    public List<SecondaryTween> secondaryTweens = new List<SecondaryTween>();
+
+    [Header("Timeline Events")]
+    [Tooltip("在时间轴特定时间点触发的模块化事件")]
+    public List<TimelineEvent> timelineEvents = new List<TimelineEvent>();
 
     [Header("Gizmos & Preview (Editor Only)")]
     public bool showPathGizmos = true;
@@ -166,6 +176,27 @@ public class UITweenController : MonoBehaviour
             seq.Join(colTween);
         }
 
+        if (secondaryTweens != null)
+        {
+            foreach (var secondary in secondaryTweens)
+            {
+                var subTween = BuildSecondaryTweener(secondary);
+                if (subTween == null) continue;
+
+                float insertTime = ResolveInsertTime(secondary.startTime, duration, reversed, secondary.duration);
+                seq.Insert(insertTime, subTween);
+            }
+        }
+
+        if (timelineEvents != null)
+        {
+            foreach (var timelineEvent in timelineEvents)
+            {
+                float insertTime = ResolveInsertTime(timelineEvent.fireTime, duration, reversed, 0f);
+                seq.InsertCallback(insertTime, () => ExecuteTimelineEvent(timelineEvent));
+            }
+        }
+
         if (loops != 0) seq.SetLoops(loops, loopType);
         return seq;
     }
@@ -214,6 +245,8 @@ public class UITweenController : MonoBehaviour
         p.targetAnchoredPosition = targetAnchoredPosition; p.targetSizeDelta = targetSizeDelta; p.targetPivot = targetPivot; p.targetEulerZ = targetEulerZ; p.targetAlpha = targetAlpha; p.targetColor = targetColor;
         p.passThroughPointC = passThroughPointC; p.passTStar = passTStar;
         p.animatePosition = animatePosition; p.animateSize = animateSize; p.animateRotationZ = animateRotationZ; p.animateAlpha = animateAlpha; p.animateColor = animateColor;
+        p.secondaryTweens = CloneSecondaryTweens(secondaryTweens);
+        p.timelineEvents = CloneTimelineEvents(timelineEvents);
 
 #if UNITY_EDITOR
         UnityEditor.EditorUtility.SetDirty(p);
@@ -232,6 +265,8 @@ public class UITweenController : MonoBehaviour
         targetAnchoredPosition = p.targetAnchoredPosition; targetSizeDelta = p.targetSizeDelta; targetPivot = p.targetPivot; targetEulerZ = p.targetEulerZ; targetAlpha = p.targetAlpha; targetColor = p.targetColor;
         passThroughPointC = p.passThroughPointC; passTStar = p.passTStar;
         animatePosition = p.animatePosition; animateSize = p.animateSize; animateRotationZ = p.animateRotationZ; animateAlpha = p.animateAlpha; animateColor = p.animateColor;
+        secondaryTweens = CloneSecondaryTweens(p.secondaryTweens);
+        timelineEvents = CloneTimelineEvents(p.timelineEvents);
     }
 
     private void ApplyEaseTo(Tween t)
@@ -259,4 +294,184 @@ public class UITweenController : MonoBehaviour
     public float PassTStar => passTStar;
     public bool UseRelativeMode => useRelativeMode;
     public bool UseBezierPath => useBezierPath;
+
+    private float ResolveInsertTime(float requestedTime, float totalDuration, bool reversed, float span)
+    {
+        if (!reversed) return Mathf.Max(0f, requestedTime);
+        float mirrored = totalDuration - requestedTime - span;
+        if (float.IsNaN(mirrored) || float.IsInfinity(mirrored)) return 0f;
+        return Mathf.Clamp(mirrored, 0f, Mathf.Max(totalDuration, 0f));
+    }
+
+    private Tweener BuildSecondaryTweener(SecondaryTween secondary)
+    {
+        if (secondary == null || secondary.duration <= 0f || _rt == null) return null;
+
+        Tweener tween = null;
+        switch (secondary.propertyType)
+        {
+            case SecondaryTweenType.Rotation:
+            {
+                Vector3 target = secondary.isRelative
+                    ? secondary.targetValue
+                    : new Vector3(_rt.localEulerAngles.x, _rt.localEulerAngles.y, secondary.targetValue.z);
+                var mode = secondary.isRelative ? RotateMode.FastBeyond360 : RotateMode.Fast;
+                tween = _rt.DORotate(target, secondary.duration, mode);
+                if (secondary.isRelative) tween.SetRelative();
+                break;
+            }
+            case SecondaryTweenType.Scale:
+            {
+                Vector3 target = secondary.targetValue;
+                if (!secondary.isRelative && Mathf.Approximately(target.z, 0f))
+                {
+                    target.z = _rt.localScale.z;
+                }
+                tween = _rt.DOScale(target, secondary.duration);
+                if (secondary.isRelative) tween.SetRelative();
+                break;
+            }
+            case SecondaryTweenType.AnchoredPosition:
+            {
+                var target = new Vector2(secondary.targetValue.x, secondary.targetValue.y);
+                tween = _rt.DOAnchorPos(target, secondary.duration);
+                if (secondary.isRelative) tween.SetRelative();
+                break;
+            }
+            case SecondaryTweenType.Alpha:
+            {
+                float value = secondary.targetValue.x;
+                if (_canvasGroup != null)
+                {
+                    float baseAlpha = _canvasGroup.alpha;
+                    float finalAlpha = Mathf.Clamp01(secondary.isRelative ? baseAlpha + value : value);
+                    tween = _canvasGroup.DOFade(finalAlpha, secondary.duration);
+                }
+                else if (_graphic != null)
+                {
+                    float baseAlpha = _graphic.color.a;
+                    float finalAlpha = Mathf.Clamp01(secondary.isRelative ? baseAlpha + value : value);
+                    tween = _graphic.DOFade(finalAlpha, secondary.duration);
+                }
+                break;
+            }
+            case SecondaryTweenType.Color:
+            {
+                if (_graphic != null)
+                {
+                    Color baseColor = _graphic.color;
+                    Color delta = secondary.targetColor;
+                    Color finalColor = secondary.isRelative ? baseColor + delta : delta;
+                    finalColor.r = Mathf.Clamp01(finalColor.r);
+                    finalColor.g = Mathf.Clamp01(finalColor.g);
+                    finalColor.b = Mathf.Clamp01(finalColor.b);
+                    finalColor.a = Mathf.Clamp01(finalColor.a);
+                    tween = _graphic.DOColor(finalColor, secondary.duration);
+                }
+                break;
+            }
+        }
+
+        if (tween != null)
+        {
+            tween.SetEase(secondary.easeType);
+        }
+        return tween;
+    }
+
+    private void ExecuteTimelineEvent(TimelineEvent timelineEvent)
+    {
+        if (timelineEvent == null) return;
+
+        switch (timelineEvent.eventType)
+        {
+            case TimelineEventType.CustomCallback:
+                timelineEvent.customCallback?.Invoke();
+                break;
+            case TimelineEventType.PlayAudio:
+                if (timelineEvent.audioClip != null)
+                {
+                    var source = GetComponent<AudioSource>();
+                    if (source != null)
+                    {
+                        source.PlayOneShot(timelineEvent.audioClip);
+                    }
+                    else
+                    {
+                        AudioSource.PlayClipAtPoint(timelineEvent.audioClip, transform.position);
+                    }
+                }
+                break;
+            case TimelineEventType.ChangeSprite:
+            {
+                var image = timelineEvent.targetImage;
+                if (image == null) image = _graphic as Image;
+                if (image != null && timelineEvent.newSprite != null)
+                {
+                    image.sprite = timelineEvent.newSprite;
+                }
+                break;
+            }
+            case TimelineEventType.BroadcastMessage:
+                if (!string.IsNullOrEmpty(timelineEvent.messageName))
+                {
+                    if (!string.IsNullOrEmpty(timelineEvent.messageParameter))
+                    {
+                        BroadcastMessage(timelineEvent.messageName, timelineEvent.messageParameter, SendMessageOptions.DontRequireReceiver);
+                    }
+                    else
+                    {
+                        BroadcastMessage(timelineEvent.messageName, SendMessageOptions.DontRequireReceiver);
+                    }
+                }
+                break;
+        }
+    }
+
+    private List<SecondaryTween> CloneSecondaryTweens(List<SecondaryTween> source)
+    {
+        var list = new List<SecondaryTween>();
+        if (source == null) return list;
+        foreach (var item in source)
+        {
+            if (item == null) continue;
+            var clone = new SecondaryTween
+            {
+                name = item.name,
+                propertyType = item.propertyType,
+                startTime = item.startTime,
+                duration = item.duration,
+                targetValue = item.targetValue,
+                easeType = item.easeType,
+                isRelative = item.isRelative,
+                targetColor = item.targetColor
+            };
+            list.Add(clone);
+        }
+        return list;
+    }
+
+    private List<TimelineEvent> CloneTimelineEvents(List<TimelineEvent> source)
+    {
+        var list = new List<TimelineEvent>();
+        if (source == null) return list;
+        foreach (var item in source)
+        {
+            if (item == null) continue;
+            var clone = new TimelineEvent
+            {
+                name = item.name,
+                fireTime = item.fireTime,
+                eventType = item.eventType,
+                audioClip = item.audioClip,
+                newSprite = item.newSprite,
+                targetImage = item.targetImage,
+                messageName = item.messageName,
+                messageParameter = item.messageParameter,
+                customCallback = item.customCallback
+            };
+            list.Add(clone);
+        }
+        return list;
+    }
 }

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenPlayer.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenPlayer.cs
@@ -272,6 +272,27 @@ public class UITweenPlayer : MonoBehaviour
             seq.Join(col);
         }
 
+        if (preset.secondaryTweens != null)
+        {
+            foreach (var secondary in preset.secondaryTweens)
+            {
+                var subTween = BuildSecondaryTweener(secondary);
+                if (subTween == null) continue;
+
+                float insertTime = ResolveInsertTime(secondary.startTime, dur, reversed, secondary.duration);
+                seq.Insert(insertTime, subTween);
+            }
+        }
+
+        if (preset.timelineEvents != null)
+        {
+            foreach (var timelineEvent in preset.timelineEvents)
+            {
+                float insertTime = ResolveInsertTime(timelineEvent.fireTime, dur, reversed, 0f);
+                seq.InsertCallback(insertTime, () => ExecuteTimelineEvent(timelineEvent));
+            }
+        }
+
         preset.ApplySequenceSettings(seq);
 
         LastPreparedPreset = preset;
@@ -320,6 +341,144 @@ public class UITweenPlayer : MonoBehaviour
         });
 
         return seq;
+    }
+
+    private float ResolveInsertTime(float requestedTime, float totalDuration, bool reversed, float span)
+    {
+        if (!reversed) return Mathf.Max(0f, requestedTime);
+
+        float mirrored = totalDuration - requestedTime - span;
+        if (float.IsNaN(mirrored) || float.IsInfinity(mirrored)) return 0f;
+        return Mathf.Clamp(mirrored, 0f, Mathf.Max(totalDuration, 0f));
+    }
+
+    private Tweener BuildSecondaryTweener(SecondaryTween secondary)
+    {
+        if (secondary == null || secondary.duration <= 0f) return null;
+
+        Tweener tween = null;
+        switch (secondary.propertyType)
+        {
+            case SecondaryTweenType.Rotation:
+            {
+                Vector3 target = secondary.isRelative
+                    ? secondary.targetValue
+                    : new Vector3(_rt.localEulerAngles.x, _rt.localEulerAngles.y, secondary.targetValue.z);
+                var mode = secondary.isRelative ? RotateMode.FastBeyond360 : RotateMode.Fast;
+                tween = _rt.DORotate(target, secondary.duration, mode);
+                if (secondary.isRelative) tween.SetRelative();
+                break;
+            }
+            case SecondaryTweenType.Scale:
+            {
+                Vector3 target = secondary.targetValue;
+                if (!secondary.isRelative && Mathf.Approximately(target.z, 0f))
+                {
+                    target.z = _rt.localScale.z;
+                }
+                tween = _rt.DOScale(target, secondary.duration);
+                if (secondary.isRelative) tween.SetRelative();
+                break;
+            }
+            case SecondaryTweenType.AnchoredPosition:
+            {
+                var target = new Vector2(secondary.targetValue.x, secondary.targetValue.y);
+                tween = _rt.DOAnchorPos(target, secondary.duration);
+                if (secondary.isRelative) tween.SetRelative();
+                break;
+            }
+            case SecondaryTweenType.Alpha:
+            {
+                float value = secondary.targetValue.x;
+                if (_cg != null)
+                {
+                    float baseAlpha = _cg.alpha;
+                    float finalAlpha = Mathf.Clamp01(secondary.isRelative ? baseAlpha + value : value);
+                    tween = _cg.DOFade(finalAlpha, secondary.duration);
+                }
+                else if (_gfx != null)
+                {
+                    float baseAlpha = _gfx.color.a;
+                    float finalAlpha = Mathf.Clamp01(secondary.isRelative ? baseAlpha + value : value);
+                    tween = _gfx.DOFade(finalAlpha, secondary.duration);
+                }
+                break;
+            }
+            case SecondaryTweenType.Color:
+            {
+                if (_gfx != null)
+                {
+                    Color baseColor = _gfx.color;
+                    Color delta = secondary.targetColor;
+                    Color finalColor = secondary.isRelative ? baseColor + delta : delta;
+                    finalColor.r = Mathf.Clamp01(finalColor.r);
+                    finalColor.g = Mathf.Clamp01(finalColor.g);
+                    finalColor.b = Mathf.Clamp01(finalColor.b);
+                    finalColor.a = Mathf.Clamp01(finalColor.a);
+                    tween = _gfx.DOColor(finalColor, secondary.duration);
+                }
+                break;
+            }
+        }
+
+        if (tween != null)
+        {
+            tween.SetEase(secondary.easeType);
+        }
+        return tween;
+    }
+
+    private void ExecuteTimelineEvent(TimelineEvent timelineEvent)
+    {
+        if (timelineEvent == null) return;
+
+        string sourceName = gameObject != null ? gameObject.name : name;
+        using (UITweenCallContext.BeginScope(this, "TimelineEvent", sourceName, timelineEvent.name))
+        {
+            switch (timelineEvent.eventType)
+            {
+                case TimelineEventType.CustomCallback:
+                    timelineEvent.customCallback?.Invoke();
+                    break;
+                case TimelineEventType.PlayAudio:
+                    if (timelineEvent.audioClip != null)
+                    {
+                        var source = GetComponent<AudioSource>();
+                        if (source != null)
+                        {
+                            source.PlayOneShot(timelineEvent.audioClip);
+                        }
+                        else
+                        {
+                            AudioSource.PlayClipAtPoint(timelineEvent.audioClip, transform.position);
+                        }
+                    }
+                    break;
+                case TimelineEventType.ChangeSprite:
+                {
+                    var image = timelineEvent.targetImage;
+                    if (image == null) image = _gfx as Image;
+                    if (image != null && timelineEvent.newSprite != null)
+                    {
+                        image.sprite = timelineEvent.newSprite;
+                    }
+                    break;
+                }
+                case TimelineEventType.BroadcastMessage:
+                    if (!string.IsNullOrEmpty(timelineEvent.messageName))
+                    {
+                        if (!string.IsNullOrEmpty(timelineEvent.messageParameter))
+                        {
+                            BroadcastMessage(timelineEvent.messageName, timelineEvent.messageParameter, SendMessageOptions.DontRequireReceiver);
+                        }
+                        else
+                        {
+                            BroadcastMessage(timelineEvent.messageName, SendMessageOptions.DontRequireReceiver);
+                        }
+                    }
+                    break;
+            }
+        }
     }
 
     private UITweenPreset FindPreset(string presetName)

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenPreset.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenPreset.cs
@@ -5,8 +5,87 @@
 // - 统一提供 ApplyEaseTo(Tween) 供 Player/Controller 复用
 // [MODIFIED] Split ApplyEaseTo into ApplyTweenSettings and ApplySequenceSettings to fix double delay issue.
 
-using UnityEngine;
+using System.Collections.Generic;
 using DG.Tweening;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.UI;
+
+public enum SecondaryTweenType
+{
+    Rotation,
+    Scale,
+    AnchoredPosition,
+    Alpha,
+    Color
+}
+
+[System.Serializable]
+public class SecondaryTween
+{
+    [Tooltip("此轨道名称，仅用于在编辑器中识别")]
+    public string name = "Secondary Animation";
+
+    [Tooltip("此动画控制的属性")]
+    public SecondaryTweenType propertyType = SecondaryTweenType.Rotation;
+
+    [Tooltip("在主时间轴上的开始时间（秒）")]
+    public float startTime = 0f;
+
+    [Tooltip("此动画自身的持续时间（秒）")]
+    public float duration = 0.5f;
+
+    [Tooltip("动画的目标值。对于旋转是欧拉角Z，对于缩放是(x,y,z)，对于位置是(x,y)")]
+    public Vector3 targetValue = Vector3.zero;
+
+    [Tooltip("缓动类型")]
+    public Ease easeType = Ease.Linear;
+
+    [Tooltip("是否使用相对值。勾选后，targetValue 将作为在动画开始瞬间的当前值基础上的增量。")]
+    public bool isRelative = true;
+
+    [Tooltip("颜色动画的目标颜色（仅在 propertyType = Color 时使用)")]
+    public Color targetColor = Color.white;
+}
+
+public enum TimelineEventType
+{
+    CustomCallback,
+    PlayAudio,
+    ChangeSprite,
+    BroadcastMessage
+}
+
+[System.Serializable]
+public class TimelineEvent
+{
+    [Tooltip("事件名称，用于识别")]
+    public string name = "New Event";
+
+    [Tooltip("事件在主时间轴上的触发时间点")]
+    public float fireTime = 0f;
+
+    [Tooltip("事件类型")]
+    public TimelineEventType eventType = TimelineEventType.CustomCallback;
+
+    [Tooltip("【PlayAudio】需要播放的音效片段")]
+    public AudioClip audioClip;
+
+    [Tooltip("【ChangeSprite】需要更换到的新 Sprite")]
+    public Sprite newSprite;
+
+    [Tooltip("【ChangeSprite】需要操作的目标 Image 组件")]
+    public Image targetImage;
+
+    [Tooltip("【BroadcastMessage】要广播的消息名称")]
+    public string messageName;
+
+    [Tooltip("【BroadcastMessage】消息的参数（可选）")]
+    public string messageParameter;
+
+    [Tooltip("【CustomCallback】自定义回调，可在此挂载任何脚本的公开方法")]
+    public UnityEvent customCallback = new UnityEvent();
+}
 
 public enum RelativeBaselineMode
 {
@@ -93,6 +172,14 @@ public class UITweenPreset : ScriptableObject
     [Header("Runtime Options")]
     [Tooltip("距离越近是否按比例缩短时长（可由调用方覆盖时长）。")]
     public bool scaleDurationByDistance = false;
+
+    [Header("Secondary Animations")]
+    [Tooltip("在主动画播放期间叠加的次级动画轨道")]
+    public List<SecondaryTween> secondaryTweens = new List<SecondaryTween>();
+
+    [Header("Timeline Events")]
+    [Tooltip("在时间轴特定时间点触发的模块化事件")]
+    public List<TimelineEvent> timelineEvents = new List<TimelineEvent>();
 
     // ===== MODIFICATION START =====
     // 原有的 ApplyEaseTo 方法已被拆分为以下两个方法，以避免双重延遲问题


### PR DESCRIPTION
## Summary
- add secondary tween and timeline event data structures to presets and expose them through the controller inspector
- extend the runtime player and controller to insert secondary tweens and fire configurable timeline events during playback
- build a visual timeline editor that plots easing curves and marks secondary animations and events for easier tuning, now including dedicated secondary track curve rendering
- ensure the editor preview captures side effects from secondary tweens and timeline events and restores them when stopping playback

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68f0a8eddc1c8329badc7a2ed1d02b9f