### PR TITLE
feat: visualize secondary tween curves and restore preview state

### DIFF
--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenControllerEditor.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/Editor/UITweenControllerEditor.cs
@@ -1,5 +1,6 @@
 #if UNITY_EDITOR
 using System;
+using System.Collections.Generic;
 using DG.Tweening;
 using UnityEditor;
 using UnityEngine;
@@ -20,6 +21,7 @@ public class UITweenControllerEditor : Editor
     Snap _snap;
     bool _hasSnap = false; // 核心状态标志：是否已经捕获快照并进入预览模式
     Tween _previewTween;
+    List<Action> _restoreActions = new List<Action>();
 
     void OnEnable()
     {
@@ -286,6 +288,15 @@ public class UITweenControllerEditor : Editor
             }
 
             var secondaryProp = serializedObject.FindProperty("secondaryTweens");
+            if (secondaryProp != null && secondaryProp.isArray)
+            {
+                for (int i = 0; i < secondaryProp.arraySize; i++)
+                {
+                    Color curveColor = Color.HSVToRGB((i * 0.2f) % 1f, 0.8f, 1f);
+                    DrawSecondaryCurve(timelineRect, totalDuration, secondaryProp.GetArrayElementAtIndex(i), curveColor);
+                }
+            }
+
             DrawSecondaryMarkers(timelineRect, totalDuration, secondaryProp, new Color(1f, 0.8f, 0f, 0.9f));
 
             var eventProp = serializedObject.FindProperty("timelineEvents");
@@ -332,6 +343,56 @@ public class UITweenControllerEditor : Editor
         var originalColor = GUI.color;
         GUI.color = color;
         GUI.Label(new Rect(rect.x + 6f, rect.y + 6f + index * 16f, 120f, 16f), label, EditorStyles.whiteMiniLabel);
+        GUI.color = originalColor;
+    }
+
+    private void DrawSecondaryCurve(Rect rect, float totalDuration, SerializedProperty secondaryTweenProp, Color color)
+    {
+        if (secondaryTweenProp == null) return;
+
+        float startTime = secondaryTweenProp.FindPropertyRelative("startTime")?.floatValue ?? 0f;
+        float duration = secondaryTweenProp.FindPropertyRelative("duration")?.floatValue ?? 0f;
+        SerializedProperty easeProp = secondaryTweenProp.FindPropertyRelative("easeType");
+        Ease easeType = easeProp != null ? (Ease)easeProp.enumValueIndex : Ease.Linear;
+        string name = secondaryTweenProp.FindPropertyRelative("name")?.stringValue ?? "Secondary";
+
+        if (duration <= 0f) return;
+
+        const int steps = 50;
+        Vector3[] points = new Vector3[steps + 1];
+        float minValue = float.MaxValue;
+        float maxValue = float.MinValue;
+
+        for (int i = 0; i <= steps; i++)
+        {
+            float normalizedTime = i / (float)steps;
+            float easedValue = DOVirtual.EasedValue(0f, 1f, normalizedTime, easeType);
+            if (easedValue < minValue) minValue = easedValue;
+            if (easedValue > maxValue) maxValue = easedValue;
+        }
+
+        if (Mathf.Approximately(maxValue, minValue))
+        {
+            maxValue = minValue + 1f;
+        }
+
+        for (int i = 0; i <= steps; i++)
+        {
+            float normalizedTime = i / (float)steps;
+            float easedValue = DOVirtual.EasedValue(0f, 1f, normalizedTime, easeType);
+            float yValueNormalized = Mathf.InverseLerp(minValue, maxValue, easedValue);
+            float absoluteTime = startTime + duration * normalizedTime;
+            float x = TimeToPixel(rect, totalDuration, absoluteTime);
+            float y = Mathf.Lerp(rect.yMax - 8f, rect.y + 24f, yValueNormalized);
+            points[i] = new Vector3(x, y);
+        }
+
+        Handles.color = color;
+        Handles.DrawAAPolyLine(2f, points);
+
+        var originalColor = GUI.color;
+        GUI.color = color;
+        GUI.Label(new Rect(points[0].x + 5f, points[0].y - 15f, 160f, 16f), name, EditorStyles.whiteMiniLabel);
         GUI.color = originalColor;
     }
 
@@ -396,7 +457,7 @@ public class UITweenControllerEditor : Editor
     {
         // 播放前先确保停止了任何旧的预览，这是一个好习惯
         SafeStopPreview();
-        
+
         var rt = C.GetComponent<RectTransform>();
         if (rt == null) return;
         var cg = C.GetComponent<CanvasGroup>();
@@ -407,6 +468,47 @@ public class UITweenControllerEditor : Editor
         _snap.alpha = cg ? cg.alpha : (g ? g.color.a : 1f);
         _snap.color = g ? g.color : Color.white;
         _hasSnap = true;
+
+        _restoreActions.Clear();
+
+        if (C.timelineEvents != null)
+        {
+            foreach (var timelineEvent in C.timelineEvents)
+            {
+                if (timelineEvent == null) continue;
+                if (timelineEvent.eventType == TimelineEventType.ChangeSprite && timelineEvent.targetImage != null)
+                {
+                    var targetImage = timelineEvent.targetImage;
+                    Sprite originalSprite = targetImage.sprite;
+                    _restoreActions.Add(() =>
+                    {
+                        if (targetImage == null) return;
+                        Undo.RecordObject(targetImage, "Restore Timeline Event Sprite");
+                        targetImage.sprite = originalSprite;
+                    });
+                }
+            }
+        }
+
+        bool scaleCaptured = false;
+        if (C.secondaryTweens != null)
+        {
+            foreach (var secTween in C.secondaryTweens)
+            {
+                if (secTween == null) continue;
+                if (secTween.propertyType == SecondaryTweenType.Scale && !scaleCaptured)
+                {
+                    Vector3 originalScale = rt.localScale;
+                    _restoreActions.Add(() =>
+                    {
+                        if (rt == null) return;
+                        Undo.RecordObject(rt, "Restore Secondary Scale");
+                        rt.localScale = originalScale;
+                    });
+                    scaleCaptured = true;
+                }
+            }
+        }
 
         // 【修改点 2】: 移除了 .OnComplete(SafeStopPreview)
         // 这样动画播放一次后就会自然停止在目标状态，而不会自动回调恢复方法
@@ -442,6 +544,15 @@ public class UITweenControllerEditor : Editor
         
         var g = C.GetComponent<UnityEngine.UI.Graphic>();
         if (g != null) { Undo.RecordObject(g, "Restore Snapshot"); g.color = _snap.color; }
+
+        if (_restoreActions != null)
+        {
+            foreach (var action in _restoreActions)
+            {
+                action?.Invoke();
+            }
+            _restoreActions.Clear();
+        }
 
         // 重置状态标志，为下一次预览做准备
         // inEditorDisable 是为了防止组件在禁用时重置标志，导致状态丢失


### PR DESCRIPTION
## Summary
- draw individual secondary tween easing curves within the visual timeline editor for clearer animation diagnostics
- record and replay restoration actions for preview side effects so secondary tweens and events revert cleanly when stopping

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f0c34091548329aff5fe21dc7e3471