### PR TITLE
Add global UI panel state management

### DIFF
--- a/ITC/Assets/Resources/UI.meta
+++ b/ITC/Assets/Resources/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e2e86a6c3d143748ad9bbcbdd5a6b18
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Resources/UI/DefaultUIPanelStateConfiguration.asset
+++ b/ITC/Assets/Resources/UI/DefaultUIPanelStateConfiguration.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5a1b55d5f0c4a4d4a9fb2d9093b4d9d4, type: 3}
+  m_Name: DefaultUIPanelStateConfiguration
+  m_EditorClassIdentifier:
+  panelStates: []

--- a/ITC/Assets/Resources/UI/DefaultUIPanelStateConfiguration.asset.meta
+++ b/ITC/Assets/Resources/UI/DefaultUIPanelStateConfiguration.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e37e8b6db33d4f84c9e8cb1d8248c2eb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UIPanelStateConfiguration.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UIPanelStateConfiguration.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 定義了遊戲中可用的所有 UI 面板狀態。
+/// </summary>
+[CreateAssetMenu(menuName = "UITween/UIPanelStateConfiguration", fileName = "UIPanelStateConfiguration")]
+public class UIPanelStateConfiguration : ScriptableObject
+{
+    [Serializable]
+    public class PanelState
+    {
+        [Tooltip("面板狀態名稱，需全局唯一。")]
+        public string stateName;
+    }
+
+    [Tooltip("當前遊戲中可用的所有面板狀態。")]
+    public List<PanelState> panelStates = new();
+
+    /// <summary>
+    /// 取得所有狀態名稱。
+    /// </summary>
+    public IEnumerable<string> GetStateNames()
+    {
+        foreach (var state in panelStates)
+        {
+            if (state == null || string.IsNullOrWhiteSpace(state.stateName))
+            {
+                continue;
+            }
+
+            yield return state.stateName.Trim();
+        }
+    }
+
+    public bool Contains(string stateName)
+    {
+        if (string.IsNullOrWhiteSpace(stateName))
+        {
+            return false;
+        }
+
+        foreach (var existing in panelStates)
+        {
+            if (existing == null)
+            {
+                continue;
+            }
+
+            if (string.Equals(existing.stateName, stateName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UIPanelStateConfiguration.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UIPanelStateConfiguration.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a1b55d5f0c4a4d4a9fb2d9093b4d9d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UIPanelStateMachine.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UIPanelStateMachine.cs
@@ -1,0 +1,327 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 簡易的 UI 面板狀態機，負責在遊戲生命週期內維護當前面板狀態。
+/// </summary>
+public class UIPanelStateMachine : MonoBehaviour
+{
+    public const string DefaultResourcePath = "UI/DefaultUIPanelStateConfiguration";
+
+    static UIPanelStateMachine _instance;
+
+    [Tooltip("面板狀態配置資源。若為空，將嘗試從 Resources/" + DefaultResourcePath + " 加載。")]
+    [SerializeField] private UIPanelStateConfiguration configuration;
+
+    [Tooltip("狀態機初始化時的默認狀態。如果留空，將使用配置中的第一個狀態。")]
+    [SerializeField] private string initialStateName;
+
+    [Serializable]
+    public class Transition
+    {
+        [Tooltip("目標狀態名稱。")]
+        public string targetState;
+
+        [Tooltip("可選的過渡動畫。若指定，將在轉換時播放。")]
+        public UITweenTrack track;
+
+        [Tooltip("播放的 Track 名稱（優先於索引）。")]
+        public string trackName;
+
+        [Tooltip("當 Track 名稱未指定時，使用的 Track 索引。")]
+        public int trackIndex;
+
+        public void Play()
+        {
+            if (track == null)
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(trackName))
+            {
+                track.PlayTrackByName(trackName);
+            }
+            else
+            {
+                track.PlayTrack(trackIndex);
+            }
+        }
+    }
+
+    [Serializable]
+    public class StateTransitions
+    {
+        [Tooltip("當前狀態名稱。")]
+        public string stateName;
+
+        [Tooltip("從當前狀態到其他狀態的過渡配置。")]
+        public List<Transition> transitions = new();
+
+        public Transition FindTransition(string target)
+        {
+            if (transitions == null)
+            {
+                return null;
+            }
+
+            foreach (var transition in transitions)
+            {
+                if (transition == null)
+                {
+                    continue;
+                }
+
+                if (string.Equals(transition.targetState, target, StringComparison.Ordinal))
+                {
+                    return transition;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    [Tooltip("針對每個狀態的過渡動畫配置。")]
+    [SerializeField] private List<StateTransitions> stateTransitions = new();
+
+    readonly Dictionary<string, StateTransitions> _transitionLookup = new(StringComparer.Ordinal);
+
+    public static UIPanelStateMachine Instance
+    {
+        get
+        {
+            EnsureInstance();
+            return _instance;
+        }
+    }
+
+    public event Action<string, string> StateTransitionRequested;
+    public event Action<string, string> StateChanged;
+
+    public string CurrentState { get; private set; }
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    static void AutoCreate()
+    {
+        EnsureInstance();
+    }
+
+    static void EnsureInstance()
+    {
+        if (_instance != null)
+        {
+            return;
+        }
+
+        var existing = FindObjectOfType<UIPanelStateMachine>();
+        if (existing != null)
+        {
+            _instance = existing;
+            DontDestroyOnLoad(existing.gameObject);
+            _instance.InitializeIfNeeded();
+            return;
+        }
+
+        var go = new GameObject("UIPanelStateMachine");
+        _instance = go.AddComponent<UIPanelStateMachine>();
+        DontDestroyOnLoad(go);
+        _instance.InitializeIfNeeded();
+    }
+
+    void Awake()
+    {
+        if (_instance != null && _instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        _instance = this;
+        DontDestroyOnLoad(gameObject);
+        InitializeIfNeeded();
+    }
+
+    void InitializeIfNeeded()
+    {
+        if (configuration == null)
+        {
+            configuration = Resources.Load<UIPanelStateConfiguration>(DefaultResourcePath);
+        }
+
+        BuildLookup();
+
+        if (!string.IsNullOrEmpty(CurrentState))
+        {
+            return;
+        }
+
+        CurrentState = ResolveInitialState();
+        if (!string.IsNullOrEmpty(CurrentState))
+        {
+            StateChanged?.Invoke(null, CurrentState);
+        }
+    }
+
+    void BuildLookup()
+    {
+        _transitionLookup.Clear();
+        if (configuration == null)
+        {
+            return;
+        }
+
+        var stateNames = new HashSet<string>(configuration.GetStateNames(), StringComparer.Ordinal);
+
+        foreach (var transitions in stateTransitions)
+        {
+            if (transitions == null || string.IsNullOrEmpty(transitions.stateName))
+            {
+                continue;
+            }
+
+            if (!stateNames.Contains(transitions.stateName))
+            {
+                continue;
+            }
+
+            if (!_transitionLookup.ContainsKey(transitions.stateName))
+            {
+                _transitionLookup.Add(transitions.stateName, transitions);
+            }
+        }
+
+        foreach (var stateName in stateNames)
+        {
+            if (!_transitionLookup.ContainsKey(stateName))
+            {
+                var transitions = new StateTransitions { stateName = stateName };
+                _transitionLookup[stateName] = transitions;
+                bool existsInList = false;
+                foreach (var existing in stateTransitions)
+                {
+                    if (existing != null && string.Equals(existing.stateName, stateName, StringComparison.Ordinal))
+                    {
+                        existsInList = true;
+                        break;
+                    }
+                }
+
+                if (!existsInList)
+                {
+                    stateTransitions.Add(transitions);
+                }
+            }
+        }
+    }
+
+    string ResolveInitialState()
+    {
+        if (configuration == null)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrEmpty(initialStateName) && configuration.Contains(initialStateName))
+        {
+            return initialStateName;
+        }
+
+        foreach (var stateName in configuration.GetStateNames())
+        {
+            if (!string.IsNullOrEmpty(stateName))
+            {
+                return stateName;
+            }
+        }
+
+        return null;
+    }
+
+    public bool RequestState(string targetState)
+    {
+        if (configuration == null || !configuration.Contains(targetState))
+        {
+            Debug.LogWarning($"UIPanelStateMachine: 嘗試切換到未定義的狀態 {targetState}。");
+            return false;
+        }
+
+        string previousState = CurrentState;
+        StateTransitionRequested?.Invoke(previousState, targetState);
+
+        if (!string.Equals(previousState, targetState, StringComparison.Ordinal))
+        {
+            PlayTransition(previousState, targetState);
+            CurrentState = targetState;
+            StateChanged?.Invoke(previousState, targetState);
+        }
+
+        return true;
+    }
+
+    void PlayTransition(string fromState, string toState)
+    {
+        if (string.IsNullOrEmpty(fromState) || string.IsNullOrEmpty(toState))
+        {
+            return;
+        }
+
+        if (!_transitionLookup.TryGetValue(fromState, out var transitions) || transitions == null)
+        {
+            return;
+        }
+
+        var transition = transitions.FindTransition(toState);
+        transition?.Play();
+    }
+
+    public IReadOnlyCollection<string> GetAllStates()
+    {
+        if (configuration == null)
+        {
+            return Array.Empty<string>();
+        }
+
+        return new List<string>(configuration.GetStateNames());
+    }
+
+    public void RegisterTransitionTrack(string fromState, string toState, UITweenTrack track, string trackName = null, int trackIndex = 0)
+    {
+        if (string.IsNullOrEmpty(fromState) || string.IsNullOrEmpty(toState))
+        {
+            return;
+        }
+
+        if (!_transitionLookup.TryGetValue(fromState, out var transitions) || transitions == null)
+        {
+            transitions = new StateTransitions { stateName = fromState };
+            _transitionLookup[fromState] = transitions;
+            bool existsInList = false;
+            foreach (var existingTransitions in stateTransitions)
+            {
+                if (existingTransitions != null && string.Equals(existingTransitions.stateName, fromState, StringComparison.Ordinal))
+                {
+                    existsInList = true;
+                    break;
+                }
+            }
+
+            if (!existsInList)
+            {
+                stateTransitions.Add(transitions);
+            }
+        }
+
+        var existing = transitions.FindTransition(toState);
+        if (existing == null)
+        {
+            existing = new Transition { targetState = toState };
+            transitions.transitions.Add(existing);
+        }
+
+        existing.track = track;
+        existing.trackName = trackName;
+        existing.trackIndex = trackIndex;
+    }
+}

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UIPanelStateMachine.cs.meta
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UIPanelStateMachine.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c3f9fe9d8b1f13438d17c8174c1d69b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenStateMachine.cs
+++ b/ITC/Assets/Scripts/唐今脚本/UI （UI相关）/UI动效/面向数据的dotween动画系统/UITweenStateMachine.cs
@@ -1,6 +1,7 @@
+using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using System.Collections.Generic;
 
 /// <summary>
 /// 響應UI交互事件，並播放對應的低優先級動畫的狀態機。
@@ -40,16 +41,55 @@ public class UITweenStateMachine : MonoBehaviour, IPointerEnterHandler, IPointer
         public string onExitPresetName;
     }
 
-    [Tooltip("狀態與動畫的綁定列表")]
+    [Serializable]
+    public class PanelStateAnimationProfile
+    {
+        [Tooltip("此配置適用的面板狀態名稱。")]
+        public string panelStateName;
+
+        [Tooltip("當處於對應面板狀態時使用的狀態動畫綁定。")]
+        public List<StateAnimationBinding> stateAnimations = new();
+
+        [Tooltip("是否響應指針事件。")]
+        public bool respondToPointerEvents = true;
+    }
+
+    [Tooltip("狀態與動畫的綁定列表（作為默認配置使用）。")]
     public List<StateAnimationBinding> stateAnimations = new List<StateAnimationBinding>();
+
+    [Tooltip("當前按鈕關注的面板狀態配置資源。")]
+    public UIPanelStateConfiguration panelStateConfiguration;
+
+    [Tooltip("針對特定面板狀態的覆蓋配置。")]
+    public List<PanelStateAnimationProfile> panelStateProfiles = new();
 
     private UITweenPlayer _player;
     private UIState _currentState = UIState.Normal;
     private bool _isInteractable = true;
+    private bool _respondToPointerEvents = true;
+    private PanelStateAnimationProfile _activePanelProfile;
+    private string _currentPanelState;
 
     void Awake()
     {
         _player = GetComponent<UITweenPlayer>();
+        SubscribeToPanelStateMachine();
+        RefreshPanelState(UIPanelStateMachine.Instance != null ? UIPanelStateMachine.Instance.CurrentState : null);
+    }
+
+    void OnEnable()
+    {
+        SubscribeToPanelStateMachine();
+    }
+
+    void OnDisable()
+    {
+        UnsubscribeFromPanelStateMachine();
+    }
+
+    void OnDestroy()
+    {
+        UnsubscribeFromPanelStateMachine();
     }
 
     /// <summary>
@@ -58,7 +98,7 @@ public class UITweenStateMachine : MonoBehaviour, IPointerEnterHandler, IPointer
     /// <param name="newState">要轉換到的新狀態</param>
     private void TransitionTo(UIState newState)
     {
-        if (!_isInteractable || _currentState == newState)
+        if (!_isInteractable || !_respondToPointerEvents || _currentState == newState)
         {
             return;
         }
@@ -88,7 +128,7 @@ public class UITweenStateMachine : MonoBehaviour, IPointerEnterHandler, IPointer
 
     private StateAnimationBinding FindBinding(UIState state)
     {
-        foreach (var binding in stateAnimations)
+        foreach (var binding in GetActiveBindings())
         {
             if (binding.state == state)
             {
@@ -102,7 +142,7 @@ public class UITweenStateMachine : MonoBehaviour, IPointerEnterHandler, IPointer
 
     public void OnPointerEnter(PointerEventData eventData)
     {
-        if (_currentState != UIState.Pressed)
+        if (_respondToPointerEvents && _currentState != UIState.Pressed)
         {
             TransitionTo(UIState.Hover);
         }
@@ -110,7 +150,7 @@ public class UITweenStateMachine : MonoBehaviour, IPointerEnterHandler, IPointer
 
     public void OnPointerExit(PointerEventData eventData)
     {
-        if (_currentState != UIState.Pressed)
+        if (_respondToPointerEvents && _currentState != UIState.Pressed)
         {
             TransitionTo(UIState.Normal);
         }
@@ -118,11 +158,21 @@ public class UITweenStateMachine : MonoBehaviour, IPointerEnterHandler, IPointer
 
     public void OnPointerDown(PointerEventData eventData)
     {
+        if (!_respondToPointerEvents)
+        {
+            return;
+        }
+
         TransitionTo(UIState.Pressed);
     }
 
     public void OnPointerUp(PointerEventData eventData)
     {
+        if (!_respondToPointerEvents)
+        {
+            return;
+        }
+
         if (_currentState == UIState.Pressed)
         {
             if (eventData.pointerCurrentRaycast.gameObject == gameObject)
@@ -140,6 +190,11 @@ public class UITweenStateMachine : MonoBehaviour, IPointerEnterHandler, IPointer
     
     public void SetSelected(bool isSelected)
     {
+        if (!_respondToPointerEvents)
+        {
+            return;
+        }
+
         if (isSelected)
         {
             if (_currentState != UIState.Selected) TransitionTo(UIState.Selected);
@@ -180,4 +235,113 @@ public class UITweenStateMachine : MonoBehaviour, IPointerEnterHandler, IPointer
             }
         }
     }
+
+    List<StateAnimationBinding> GetActiveBindings()
+    {
+        if (_activePanelProfile != null && _activePanelProfile.stateAnimations != null && _activePanelProfile.stateAnimations.Count > 0)
+        {
+            return _activePanelProfile.stateAnimations;
+        }
+
+        return stateAnimations ??= new List<StateAnimationBinding>();
+    }
+
+    void SubscribeToPanelStateMachine()
+    {
+        var machine = UIPanelStateMachine.Instance;
+        if (machine == null)
+        {
+            return;
+        }
+
+        machine.StateTransitionRequested -= HandlePanelStateRequested;
+        machine.StateTransitionRequested += HandlePanelStateRequested;
+    }
+
+    void UnsubscribeFromPanelStateMachine()
+    {
+        var machine = UIPanelStateMachine.Instance;
+        if (machine == null)
+        {
+            return;
+        }
+
+        machine.StateTransitionRequested -= HandlePanelStateRequested;
+    }
+
+    void HandlePanelStateRequested(string _, string targetState)
+    {
+        RefreshPanelState(targetState);
+    }
+
+    void RefreshPanelState(string targetState)
+    {
+        _currentPanelState = targetState;
+        _activePanelProfile = null;
+        _respondToPointerEvents = false;
+
+        if (string.IsNullOrEmpty(targetState))
+        {
+            ResetToNormal();
+            return;
+        }
+
+        if (panelStateConfiguration != null && !panelStateConfiguration.Contains(targetState))
+        {
+            ResetToNormal();
+            return;
+        }
+
+        foreach (var profile in panelStateProfiles)
+        {
+            if (profile == null || string.IsNullOrEmpty(profile.panelStateName))
+            {
+                continue;
+            }
+
+            if (string.Equals(profile.panelStateName, targetState, StringComparison.Ordinal))
+            {
+                _activePanelProfile = profile;
+                bool hasBindings = GetActiveBindings() != null && GetActiveBindings().Count > 0;
+                _respondToPointerEvents = profile.respondToPointerEvents && hasBindings;
+                if (!_respondToPointerEvents)
+                {
+                    ResetToNormal();
+                }
+                return;
+            }
+        }
+
+        // 未配置的面板狀態不響應指針事件。
+        ResetToNormal();
+    }
+
+    void ResetToNormal()
+    {
+        _currentState = UIState.Normal;
+    }
+
+#if UNITY_EDITOR
+    void OnValidate()
+    {
+        if (panelStateProfiles == null || panelStateConfiguration == null)
+        {
+            return;
+        }
+
+        var validNames = new HashSet<string>(panelStateConfiguration.GetStateNames(), StringComparer.Ordinal);
+        foreach (var profile in panelStateProfiles)
+        {
+            if (profile == null || string.IsNullOrEmpty(profile.panelStateName))
+            {
+                continue;
+            }
+
+            if (!validNames.Contains(profile.panelStateName))
+            {
+                profile.panelStateName = string.Empty;
+            }
+        }
+    }
+#endif
 }


### PR DESCRIPTION
## Summary
- add a persistent `UIPanelStateMachine` that loads panel configuration, survives scene changes, and plays registered transition tracks
- introduce a `UIPanelStateConfiguration` ScriptableObject plus a default Resources asset for defining available UI panel states
- update `UITweenStateMachine` to subscribe to panel state change requests and enable pointer-driven tweens only for configured panel states

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_69003cb0a34483299b9dfd3814292f6c